### PR TITLE
netstat not to resolve IP addresses

### DIFF
--- a/pscheduler-core/pscheduler-core/diags
+++ b/pscheduler-core/pscheduler-core/diags
@@ -97,7 +97,7 @@ ip route
 
 
 section Sockets
-netstat -a
+netstat -n -a
 
 
 #


### PR DESCRIPTION
Resolving IP addresses could be slowish. Is there real need to have hostnames?