### PR TITLE
IP CIDR List support for auto-detecting local IPs

### DIFF
--- a/python-pscheduler/pscheduler/pscheduler/limitprocessor/identifier/ipcidrlist.py
+++ b/python-pscheduler/pscheduler/pscheduler/limitprocessor/identifier/ipcidrlist.py
@@ -4,19 +4,13 @@ Identifier Class for ip-cidr-list
 
 import ipaddr
 import pscheduler
-import netifaces
 
 data_validator = {
     "type": "object",
     "properties": {
         "cidrs": {
             "type": "array",
-            "items": { 
-                "anyOf": [ 
-                    {"$ref": "#/pScheduler/IPCIDR"}, 
-                    {"type": "string", "enum": ["local"]}
-                ] 
-            }
+            "items": { "$ref": "#/pScheduler/IPCIDR" }
         },
     },
     "required": [ "cidrs" ]
@@ -48,20 +42,7 @@ class IdentifierIPCIDRList():
 
         self.cidrs = []
         for cidr in data['cidrs']:
-            if cidr == 'local':
-                for iface in netifaces.interfaces():
-                    ifaddrs = netifaces.ifaddresses(iface)
-                    if netifaces.AF_INET in ifaddrs:
-                        for ifaddr in ifaddrs[netifaces.AF_INET]:
-                            if 'addr' in ifaddr:
-                                self.cidrs.append(ipaddr.IPNetwork(ifaddr['addr']))
-                    if netifaces.AF_INET6 in ifaddrs:
-                        for ifaddr in ifaddrs[netifaces.AF_INET6]:
-                            if 'addr' in ifaddr:
-                                #add v6 but remove stuff like %eth0 that gets thrown on end of some addrs
-                                self.cidrs.append(ipaddr.IPNetwork(ifaddr['addr'].split('%')[0]))
-            else:
-                self.cidrs.append(ipaddr.IPNetwork(cidr))
+            self.cidrs.append(ipaddr.IPNetwork(cidr))
 
 
 

--- a/python-pscheduler/pscheduler/pscheduler/limitprocessor/identifier/localif.py
+++ b/python-pscheduler/pscheduler/pscheduler/limitprocessor/identifier/localif.py
@@ -1,0 +1,82 @@
+"""
+Identifier Class for localif
+"""
+
+import ipaddr
+import pscheduler
+import netifaces
+
+def data_is_valid(data):
+    """Check to see if data is valid for this class.  Returns a tuple of
+    (bool, string) indicating valididty and any error message.
+    """
+
+    if type(data) == dict and len(data) == 0:
+        return True, None
+
+    return False, "Data is not an object or not empty."
+
+
+class IdentifierLocalIF():
+
+
+    """
+    Class that holds and processes identifiers
+    """
+
+
+    def __init__(self,
+                 data   # Data suitable for this class
+                 ):
+
+        valid, message = data_is_valid(data)
+        if not valid:
+            raise ValueError("Invalid data: %s" % message)
+
+        self.cidrs = []
+        for iface in netifaces.interfaces():
+            ifaddrs = netifaces.ifaddresses(iface)
+            if netifaces.AF_INET in ifaddrs:
+                for ifaddr in ifaddrs[netifaces.AF_INET]:
+                    if 'addr' in ifaddr:
+                        self.cidrs.append(ipaddr.IPNetwork(ifaddr['addr']))
+            if netifaces.AF_INET6 in ifaddrs:
+                for ifaddr in ifaddrs[netifaces.AF_INET6]:
+                    if 'addr' in ifaddr:
+                        #add v6 but remove stuff like %eth0 that gets thrown on end of some addrs
+                        self.cidrs.append(ipaddr.IPNetwork(ifaddr['addr'].split('%')[0]))
+
+
+
+    def evaluate(self,
+                 hints  # Information used for doing identification
+                 ):
+
+        """Given a set of hints, evaluate this identifier and return True if
+        an identification is made.
+
+        """
+
+        try:
+            ip = ipaddr.IPNetwork(hints['ip'])
+        except KeyError:
+            return False
+
+        # TODO: Find out of there's a more hash-like way to do this
+        # instead of a linear search.  This would be great if it
+        # weren't GPL: https://pypi.python.org/pypi/pytricia
+
+        for cidr in self.cidrs:
+            if ip in cidr:
+                return True
+
+        return False
+
+# A short test program
+
+if __name__ == "__main__":
+
+    ident = IdentifierLocalIF({})
+
+    for ip in [ "127.0.0.1", "::1", "10.1.1.1", "198.129.254.30" ]:
+        print ip, ident.evaluate({ "ip": ip })

--- a/python-pscheduler/pscheduler/pscheduler/limitprocessor/identifierset.py
+++ b/python-pscheduler/pscheduler/pscheduler/limitprocessor/identifierset.py
@@ -11,6 +11,7 @@ from .identifier import ipcidrlist
 from .identifier import ipcidrlisturl
 from .identifier import ipcymrubogon
 from .identifier import ipreversedns
+from .identifier import localif
 
 identifier_creator = {
     'always':           lambda data: always.IdentifierAlways(data),
@@ -18,7 +19,8 @@ identifier_creator = {
     'ip-cidr-list':     lambda data: ipcidrlist.IdentifierIPCIDRList(data),
     'ip-cidr-list-url': lambda data: ipcidrlisturl.IdentifierIPCIDRListURL(data),
     'ip-cymru-bogon':   lambda data: ipcymrubogon.IdentifierIPCymruBogon(data),
-    'ip-reverse-dns':   lambda data: ipreversedns.IdentifierIPReverseDNS(data)
+    'ip-reverse-dns':   lambda data: ipreversedns.IdentifierIPReverseDNS(data),
+    'localif':          lambda data: localif.IdentifierLocalIF(data)
     }
 
 

--- a/python-pscheduler/python-pscheduler.spec
+++ b/python-pscheduler/python-pscheduler.spec
@@ -24,6 +24,7 @@ Requires:	python-dnspython
 Requires:	python-isodate
 Requires:	python-jsonschema
 Requires:	python-netaddr
+Requires:	python-netifaces
 Requires:	python-ntplib
 Requires:	python-psycopg2 >= 2.2.0
 Requires:	python-py-radix

--- a/python-pscheduler/python-pscheduler.spec
+++ b/python-pscheduler/python-pscheduler.spec
@@ -24,7 +24,6 @@ Requires:	python-dnspython
 Requires:	python-isodate
 Requires:	python-jsonschema
 Requires:	python-netaddr
-Requires:	python-netifaces
 Requires:	python-ntplib
 Requires:	python-psycopg2 >= 2.2.0
 Requires:	python-py-radix


### PR DESCRIPTION
A frequent issue i ran into when using the default limits file is that very rarely does pscheduler identify my host as 127.0.0.1 when I am running from local host. Instead it usually grabs one of the other ips. I can of course add that IP to the limits, but this is extra work for most people that we'd like to avoid having them do.

This pull requests adds a special keyword 'local' that you can give to an ipcidr list. Example:

```
{
	    "name": "very-trusted-hosts",
	    "description": "Hosts we trust",
	    "type": "ip-cidr-list",
	    "data": {
		"cidrs": [
		    "local"
		]
	    }
}

```
 If it sees this keyword, it will poll the system for the list of interfaces and add all IPv4 and IPv6 addresses to the list. It uses the python-netifaces package, which should be available for all supported operating systems. 