### PR TITLE
Issue #536 BugFix

### DIFF
--- a/pscheduler-test-snmpget/snmpget/spec-to-cli
+++ b/pscheduler-test-snmpget/snmpget/spec-to-cli
@@ -14,7 +14,10 @@ if not valid:
     pscheduler.fail(message)
 
 # concatenate oids
-oid_list = spec['oid']
+try:
+    oid_list = spec['oid']
+except KeyError:
+    pscheduler.fail("Must query at least one OID.")
 oid_str = ""
 for item in oid_list:
     oid_str = "%s,%s" % (oid_str, item)

--- a/pscheduler-test-snmpgetbgm/snmpgetbgm/spec-to-cli
+++ b/pscheduler-test-snmpgetbgm/snmpgetbgm/spec-to-cli
@@ -14,7 +14,10 @@ if not valid:
     pscheduler.fail(message)
 
 # concatenate oids
-oid_list = spec['oid']
+try:
+    oid_list = spec['oid']
+except KeyError:
+    pscheduler.fail("Must query at least one OID.")
 oid_str = ""
 for item in oid_list:
     oid_str = "%s,%s" % (oid_str, item)


### PR DESCRIPTION
Fixing the issue listed here https://github.com/perfsonar/pscheduler/issues/536 for both snmpget and snmpgetbgm.

Now if "pscheduler task snmpget/snmpgetbgm" is run without any OID, pscheduler.fail will be called with a message saying that at least one oid must be queried.