### PR TITLE
pscheduler-tool-twping: use reverse flag instead of flip

### DIFF
--- a/pscheduler-test-latency/latency/cli-to-spec
+++ b/pscheduler-test-latency/latency/cli-to-spec
@@ -114,6 +114,10 @@ opt_parser.add_option("-f", "--flip",
                       help="In multi-participant mode, have the dest start the client and request a reverse test. Useful in some firewall and NAT environments.",
                       action="store_true", dest="flip", default=False)
 
+opt_parser.add_option("-r", "--reverse",
+                      help="Report results in the reverse direction (destination to source) if possible.",
+                      action="store_true", dest="reverse", default=False)
+
 opt_parser.add_option("-R", "--output-raw",
                       help="Output individual packet statistics. This will substantially increase the size of a successful result.",
                       action="store_true", dest="output_raw", default=False)
@@ -177,6 +181,9 @@ if options.bucket_width is not None:
 
 if options.flip:
    result['flip'] = options.flip
+
+if options.reverse:
+   result['reverse'] = options.reverse
 
 if options.output_raw:
    result['output-raw'] = options.output_raw

--- a/pscheduler-test-latency/latency/limit-passes
+++ b/pscheduler-test-latency/latency/limit-passes
@@ -72,6 +72,7 @@ def check_limit(input_json):
     booleans = [
         ("output-raw", "Output Raw"),
         ("flip", "Flip")
+        ("reverse", "Reverse")
     ]
     for b in booleans:
         errors += pscheduler.check_boolean_limit(limit, spec, b[0], description=b[1])

--- a/pscheduler-test-latency/latency/spec-format
+++ b/pscheduler-test-latency/latency/spec-format
@@ -29,6 +29,7 @@ IP Version .......... {.section ip-version}IPv{@}{.or}Not Specified{.end}
 Bucket Width ........ {.section bucket-width}{@}{.or}Not Specified{.end}
 Output Raw Packets .. {.section output-raw}{@}{.or}Not Specified{.end}
 Flip Mode ........... {.section flip}{@}{.or}Not Specified{.end}
+Reverse Mode ........ {.section reverse}{@}{.or}Not Specified{.end}
    """
 else:
 

--- a/pscheduler-test-latency/latency/validate.py
+++ b/pscheduler-test-latency/latency/validate.py
@@ -88,6 +88,10 @@ REQUEST_SCHEMA = {
                 "description": "In multi-participant mode, have the dest start the client and request a reverse test. Useful in some firewall and NAT environments.",
                 "$ref": "#/pScheduler/Boolean"
             },
+            "reverse": {
+                "description": "Report results in the reverse direction (destination to source) if possible.",
+                "$ref": "#/pScheduler/Boolean"
+            },
 
         },
 
@@ -277,6 +281,7 @@ LIMIT_SCHEMA = {
         "bucket-width":     { "$ref": "#/local/bucket-width-limit" },
         "output-raw":       { "$ref": "#/pScheduler/Limit/Boolean" },
         "flip":             { "$ref": "#/pScheduler/Limit/Boolean" },
+        "reverse":          { "$ref": "#/pScheduler/Limit/Boolean" },
     },
     "additionalProperties": False
 }

--- a/pscheduler-test-latency/tests/cli-to-spec_test.py
+++ b/pscheduler-test-latency/tests/cli-to-spec_test.py
@@ -105,6 +105,7 @@ class CliToSpecTest(pscheduler.TestCliToSpecUnitTest):
                 "val": "10.0.0.2"
             },
             "flip": {},
+            "reverse": {},
             "output-raw": {}
         })
         
@@ -147,6 +148,7 @@ class CliToSpecTest(pscheduler.TestCliToSpecUnitTest):
                 "short": "b"
             },
             "flip": {"short": "f"},
+            "reverse": {"short": "r"},
             "output-raw": {"short": "R"}
         })
 

--- a/pscheduler-test-latency/tests/limit-is-valid_test.py
+++ b/pscheduler-test-latency/tests/limit-is-valid_test.py
@@ -186,6 +186,14 @@ class LimitIsValidTest(pscheduler.TestLimitIsValidUnitTest):
         ##out of range
         self.assert_cmd('{"flip": {"match": 1}}', expected_valid=False)
         
+    def test_reverse(self):
+        #test reverse
+        ##in range
+        self.assert_cmd('{"reverse": {"match": true}}')
+        self.assert_cmd('{"reverse": {"match": false}}')
+        ##out of range
+        self.assert_cmd('{"reverse": {"match": 1}}', expected_valid=False)
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/pscheduler-test-latency/tests/limit-passes_test.py
+++ b/pscheduler-test-latency/tests/limit-passes_test.py
@@ -65,6 +65,9 @@ class LatencyLimitPassesTest(pscheduler.TestLimitPassesUnitTest):
     def test_flip(self): 
         self.assert_boolean_limit('flip', 'Flip')
         
+    def test_reverse(self):
+        self.assert_boolean_limit('reverse', 'Flip')
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/pscheduler-test-latency/tests/spec-format_test.py
+++ b/pscheduler-test-latency/tests/spec-format_test.py
@@ -28,6 +28,7 @@ IP Version .......... IPv6
 Bucket Width ........ Not Specified
 Output Raw Packets .. Not Specified
 Flip Mode ........... True
+Reverse Mode ........ False
         """
         self.assert_formatted_output("text/plain", input, expected_stdout=expected_stdout)
         

--- a/pscheduler-test-latency/tests/spec-to-cli_test.py
+++ b/pscheduler-test-latency/tests/spec-to-cli_test.py
@@ -99,12 +99,14 @@ class CliToSpecTest(pscheduler.TestSpecToCliUnitTest):
             '--source': '10.0.0.1',
             '--dest': '10.0.0.2',
             '--flip': None,
+            '--reverse': None,
             '--output-raw': None,
         }
         self.assert_spec_to_cli("""
             { "source": "10.0.0.1", 
               "dest": "10.0.0.2", 
               "flip": true,
+              "reverse": true,
               "output-raw": true}""", expected_args)
 
     def test_failure(self):

--- a/pscheduler-tool-twping/twping/run
+++ b/pscheduler-tool-twping/twping/run
@@ -37,7 +37,7 @@ except KeyError as e:
     pscheduler.fail("Missing required key in run input: %s" % e)
 except:
     pscheduler.fail("Error parsing run input: %s" % sys.exc_info()[0])
-flip = test_spec.get('flip', False)
+reverse = test_spec.get('reverse', False)
 
 #constants
 TIME_SCALE = .001 #use for millisecond conversions
@@ -179,7 +179,7 @@ if role == CLIENT_ROLE:
     for line in stdout_lines:
         twping_match = twping_regex.match(line)
         if twping_match:
-            if flip:
+            if reverse:
                 seq_number               = twping_match.group(9);
                 source_timestamp         = twping_match.group(10);
                 source_synchronized      = twping_match.group(11);


### PR DESCRIPTION
Reports latency from destination to source.