### PR TITLE
pscheduler-tool-twping: add rtt test support #625

### DIFF
--- a/pscheduler-test-rtt/rtt/cli-to-spec
+++ b/pscheduler-test-rtt/rtt/cli-to-spec
@@ -125,6 +125,10 @@ opt_parser.add_option("--timeout",
                       action="store", type="string",
                       dest="timeout")
 
+opt_parser.add_option("--protocol",
+                      help="Protocol used to measure round trip time",
+                      action="store", type="string",
+                      dest="protocol")
 
 
 (options, remaining_args) = opt_parser.parse_args(args)
@@ -133,7 +137,8 @@ if len(remaining_args) != 0:
    pscheduler.fail("Unusable arguments: %s" % " ".join(remaining_args))
 
 
-result = { 'schema': 1 }
+result = { }
+schema = pscheduler.HighInteger(1)
 
 
 if options.count is not None:
@@ -178,5 +183,10 @@ if options.deadline is not None:
 if options.timeout is not None:
    result['timeout'] = options.timeout
 
+if options.protocol is not None:
+   result['protocol'] = options.protocol
+   schema.set(2)
+
+result["schema"] = schema.value()
 
 pscheduler.succeed_json(result)

--- a/pscheduler-test-rtt/rtt/participants
+++ b/pscheduler-test-rtt/rtt/participants
@@ -8,7 +8,7 @@ import sys
 
 from validate import spec_is_valid
 
-json = pscheduler.json_load(exit_on_error=True, max_schema=1)
+json = pscheduler.json_load(exit_on_error=True, max_schema=2)
 
 null_reason = None
 

--- a/pscheduler-test-rtt/rtt/spec-format
+++ b/pscheduler-test-rtt/rtt/spec-format
@@ -16,7 +16,7 @@ except IndexError:
    format = 'text/plain'
 
 
-json = pscheduler.json_load(exit_on_error=True, max_schema=1)
+json = pscheduler.json_load(exit_on_error=True, max_schema=2)
 
 valid, message = spec_is_valid(json)
 
@@ -39,6 +39,7 @@ Packet Length ................. {.section length}{length}{.or}Not Specified{.end
 Time to Live .................. {.section ttl}{ttl}{.or}Not Specified{.end}
 Deadline ...................... {.section deadline}{deadline}{.or}Not Specified{.end}
 Timeout .,..................... {.section timeout}{timeout}{.or}Not Specified{.end}
+Protocol .,.................... {.section protocol}{protocol}{.or}Not Specified{.end}
 """
 
 elif format == 'text/html':
@@ -57,6 +58,7 @@ elif format == 'text/html':
 <tr><td>Time to Live</td><td>{.section ttl}{ttl}{.or}Not Specified{.end}</td></tr>
 <tr><td>Deadline</td><td>{.section deadline}{deadline}{.or}Not Specified{.end}</td></tr>
 <tr><td>Timeout</td><td>{.section timeout}{timeout}{.or}Not Specified{.end}</td></tr>
+<tr><td>Protocol</td><td>{.section protocol}{protocol}{.or}Not Specified{.end}</td></tr>
 </table>
    """
 

--- a/pscheduler-test-rtt/rtt/spec-is-valid
+++ b/pscheduler-test-rtt/rtt/spec-is-valid
@@ -9,8 +9,8 @@ from validate import spec_is_valid
 
 
 try:
-    json = pscheduler.json_load(max_schema=1)
-    pscheduler.json_check_schema(json, 1)
+    json = pscheduler.json_load(max_schema=2)
+    pscheduler.json_check_schema(json, 2)
 except ValueError as ex:
     pscheduler.succeed_json({
         "valid": False,

--- a/pscheduler-test-rtt/rtt/spec-to-cli
+++ b/pscheduler-test-rtt/rtt/spec-to-cli
@@ -6,7 +6,7 @@ import pscheduler
 
 from validate import spec_is_valid
 
-spec = pscheduler.json_load(exit_on_error=True, max_schema=1)
+spec = pscheduler.json_load(exit_on_error=True, max_schema=2)
 
 valid, message = spec_is_valid(spec)
 
@@ -29,6 +29,7 @@ result = pscheduler.speccli_build_args(spec,
         ( 'ttl', 'ttl' ),
         ( 'deadline', 'deadline' ),
         ( 'timeout', 'timeout' ),
+        ( 'protocol', 'protocol' ),
         ],
                                        bools=[
         ( 'suppress-loopback', 'suppress-loopback' ),

--- a/pscheduler-test-rtt/rtt/validate.py
+++ b/pscheduler-test-rtt/rtt/validate.py
@@ -6,30 +6,73 @@ from pscheduler import json_validate
 
 def spec_is_valid(json):
     schema = {
-        "type": "object",
-        "properties": {
-            "schema":            { "$ref": "#/pScheduler/Cardinal" },
-            "count":             { "$ref": "#/pScheduler/Cardinal" },
-            "dest":              { "$ref": "#/pScheduler/Host" },
-            # There is no dest-node because this is a one-participant test.
-            # TODO: This is supposed to be a 20-bit number.  Validate that.
-            "flow-label":        { "$ref": "#/pScheduler/CardinalZero" },
-            "hostnames":         { "$ref": "#/pScheduler/Boolean" },
-            "interval":          { "$ref": "#/pScheduler/Duration" },
-            "ip-version":        { "$ref": "#/pScheduler/ip-version" },
-            "source":            { "$ref": "#/pScheduler/Host" },
-            "source-node":       { "$ref": "#/pScheduler/URLHostPort" },
-            "suppress-loopback": { "$ref": "#/pScheduler/Boolean" },
-            "ip-tos":            { "$ref": "#/pScheduler/IPTOS" },
-            "length":            { "$ref": "#/pScheduler/Cardinal" },
-            "ttl":               { "$ref": "#/pScheduler/Cardinal" },
-            "deadline":          { "$ref": "#/pScheduler/Duration" },
-            "timeout":           { "$ref": "#/pScheduler/Duration" },
+        "local" : {
+            "protocol": {
+                "type": "string",
+                "enum": ["icmp", "twamp"]
             },
-        "required": [
-            "dest"
-            ]
-        }
+            "rtt_v1": {
+                "type": "object",
+                "properties": {
+                    "schema":            { "$ref": "#/pScheduler/Cardinal" },
+                    "count":             { "$ref": "#/pScheduler/Cardinal" },
+                    "dest":              { "$ref": "#/pScheduler/Host" },
+                    # There is no dest-node because this is a one-participant test.
+                    # TODO: This is supposed to be a 20-bit number.  Validate that.
+                    "flow-label":        { "$ref": "#/pScheduler/CardinalZero" },
+                    "hostnames":         { "$ref": "#/pScheduler/Boolean" },
+                    "interval":          { "$ref": "#/pScheduler/Duration" },
+                    "ip-version":        { "$ref": "#/pScheduler/ip-version" },
+                    "source":            { "$ref": "#/pScheduler/Host" },
+                    "source-node":       { "$ref": "#/pScheduler/URLHostPort" },
+                    "suppress-loopback": { "$ref": "#/pScheduler/Boolean" },
+                    "ip-tos":            { "$ref": "#/pScheduler/IPTOS" },
+                    "length":            { "$ref": "#/pScheduler/Cardinal" },
+                    "ttl":               { "$ref": "#/pScheduler/Cardinal" },
+                    "deadline":          { "$ref": "#/pScheduler/Duration" },
+                    "timeout":           { "$ref": "#/pScheduler/Duration" },
+                    },
+                "required": [
+                    "dest"
+                    ]
+            },
+            "rtt_v2": {
+                "type": "object",
+                "properties": {
+                    "schema":            { "$ref": "#/pScheduler/Cardinal" },
+                    "count":             { "$ref": "#/pScheduler/Cardinal" },
+                    "dest":              { "$ref": "#/pScheduler/Host" },
+                    # There is no dest-node because this is a one-participant test.
+                    # TODO: This is supposed to be a 20-bit number.  Validate that.
+                    "flow-label":        { "$ref": "#/pScheduler/CardinalZero" },
+                    "hostnames":         { "$ref": "#/pScheduler/Boolean" },
+                    "interval":          { "$ref": "#/pScheduler/Duration" },
+                    "ip-version":        { "$ref": "#/pScheduler/ip-version" },
+                    "source":            { "$ref": "#/pScheduler/Host" },
+                    "source-node":       { "$ref": "#/pScheduler/URLHostPort" },
+                    "suppress-loopback": { "$ref": "#/pScheduler/Boolean" },
+                    "ip-tos":            { "$ref": "#/pScheduler/IPTOS" },
+                    "length":            { "$ref": "#/pScheduler/Cardinal" },
+                    "ttl":               { "$ref": "#/pScheduler/Cardinal" },
+                    "deadline":          { "$ref": "#/pScheduler/Duration" },
+                    "timeout":           { "$ref": "#/pScheduler/Duration" },
+                    "protocol":          { "$ref": "#/local/protocol" },
+                    },
+                "required": [
+                    "dest"
+                    ]
+            },
+            "rtt": {
+                "anyOf": [
+                    { "$ref": "#/local/rtt_v1" },
+                    { "$ref": "#/local/rtt_v2" }
+                ]
+            }
+        },
+
+        "$ref": "#/local/rtt"
+    }
+
     return json_validate(json, schema)
 
 

--- a/pscheduler-tool-ping/ping/can-run
+++ b/pscheduler-tool-ping/ping/can-run
@@ -28,7 +28,7 @@ except KeyError:
 
 try:
     spec = json["spec"]
-    pscheduler.json_check_schema(spec, 1)
+    pscheduler.json_check_schema(spec, 2)
 except KeyError:
     pscheduler.succeed_json({
         "can-run": False,
@@ -60,6 +60,9 @@ except KeyError:
 
 if 'flow-label' in spec and ip_version != 6:
     errors.append("Cannot apply flow labels except with IPv6")
+
+if 'protocol' in spec and spec['protocol'] != 'icmp':
+    errors.append("Only icmp protocol is supported")
 
 
 result = {

--- a/pscheduler-tool-twping/twping/can-run
+++ b/pscheduler-tool-twping/twping/can-run
@@ -24,7 +24,7 @@ except KeyError:
 
 try:
     spec = json["spec"]
-    pscheduler.json_check_schema(spec, 1)
+    pscheduler.json_check_schema(spec, 2)
 except KeyError:
     pscheduler.succeed_json({
         "can-run": False,
@@ -36,6 +36,10 @@ except ValueError as ex:
         "reasons": [str(ex)]
     })
 
-
+if 'protocol' not in spec or spec['protocol'] != 'twamp':
+    pscheduler.succeed_json({
+        "can-run": False,
+        "reasons": ["Only twamp protocol is supported"]
+    })
 
 pscheduler.succeed_json({ "can-run": True })

--- a/pscheduler-tool-twping/twping/can-run
+++ b/pscheduler-tool-twping/twping/can-run
@@ -11,7 +11,7 @@ import pscheduler
 json = pscheduler.json_load(exit_on_error=True)
 
 try:
-    if json['type'] != 'latency':
+    if json['type'] not in [ 'latency', 'rtt' ]:
         pscheduler.succeed_json({
             "can-run": False,
             "reasons": [ "Unsupported test type" ]

--- a/pscheduler-tool-twping/twping/enumerate
+++ b/pscheduler-tool-twping/twping/enumerate
@@ -3,9 +3,9 @@
     "schema": 1,
 
     "name": "twping",
-    "description": "Determine one-way latency with TWAMP",
+    "description": "Determine latency with TWAMP",
     "version": "1.0",
-    "tests": [ "latency" ],
+    "tests": [ "latency", "rtt" ],
 
     "preference": 0,
 

--- a/pscheduler-tool-twping/twping/run
+++ b/pscheduler-tool-twping/twping/run
@@ -4,7 +4,9 @@
 #
 
 import datetime
+import ipaddr
 import json
+import math
 import pscheduler
 import re
 import tempfile
@@ -42,6 +44,7 @@ reverse = test_spec.get('reverse', False)
 #constants
 TIME_SCALE = .001 #use for millisecond conversions
 DEFAULT_TWPING_CMD = '/usr/bin/twping'
+DEFAULT_TWPING_LENGTH = 41
 DEFAULT_BUCKET_WIDTH = TIME_SCALE #convert to ms
 DELAY_BUCKET_DIGITS = 2 #number of digits to round delay buckets
 DELAY_BUCKET_FORMAT = '%.2f' #Set buckets to nearest 2 decimal places
@@ -74,7 +77,7 @@ if role == CLIENT_ROLE:
     #TODO: Get path to twping from config file
     #Always use raw output (-R)
     twping_args = [twping_cmd, '-R']
-    
+
     #build basic arguments
     for arg in TWPING_VAL_ARGS:
         if arg[0] in test_spec:
@@ -85,13 +88,20 @@ if role == CLIENT_ROLE:
             twping_args.append(rarg[1])
             twping_args.append("%d-%d" % (test_spec[rarg[0]]['lower'], test_spec[rarg[0]]['upper']))
             
+    #set packet size for rtt tests to match ping
+    rtt_length = DEFAULT_TWPING_LENGTH
+    if 'length' in test_spec and test_spec['length'] > DEFAULT_TWPING_LENGTH:
+        rtt_length = test_spec['length'] + 8
+        twping_args.append('-s')
+        twping_args.append(str(test_spec['length'] - 6))
+
     #set interval,count and timeout to ensure consistent with duration
     twping_args.append('-c')
-    twping_args.append(str(test_spec.get('packet-count', DEFAULT_PACKET_COUNT)))
+    twping_args.append(str(test_spec.get('packet-count', test_spec.get('count', DEFAULT_PACKET_COUNT))))
     twping_args.append('-i')
-    twping_args.append(str(test_spec.get('packet-interval', DEFAULT_PACKET_INTERVAL)))
+    twping_args.append(str(test_spec.get('packet-interval', test_spec.get('interval', DEFAULT_PACKET_INTERVAL))))
     twping_args.append('-L')
-    twping_args.append(str(test_spec.get('packet-timeout', DEFAULT_PACKET_TIMEOUT)))
+    twping_args.append(str(test_spec.get('packet-timeout', test_spec.get('timeout', DEFAULT_PACKET_TIMEOUT))))
     
     #set if ipv4 only or ipv6 only
     ip_version = str(test_spec.get('ip-version', ''))
@@ -99,6 +109,18 @@ if role == CLIENT_ROLE:
         twping_args.append('-4')
     elif ip_version == '6':
         twping_args.append('-6')
+
+    #calculate destination ip for rtt tests
+    try:
+            ipaddr.IPAddress(test_spec['dest'])
+            dest_ip = test_spec['dest']
+            dest_hostname = pscheduler.dns_resolve_reverse(dest_ip)
+    except ValueError:
+        dest_hostname = test_spec['dest']
+        if ip_version == '6':
+            dest_ip = pscheduler.dns_resolve(test_spec['dest'], ip_version=6)
+        else:
+            dest_ip = pscheduler.dns_resolve(test_spec['dest'], ip_version=4)
     
     #bucket width is used for rounding delay values used as buckets for histogram
     bucket_width = test_spec.get('bucket-width', DEFAULT_BUCKET_WIDTH)
@@ -174,6 +196,8 @@ if role == CLIENT_ROLE:
     packets_seen = {}
     prev_seq_number = -1
     stdout_lines = []
+    roundtrips = []
+    rtts = []
     if stdout:
         stdout_lines = stdout.split("\n")
     for line in stdout_lines:
@@ -197,7 +221,23 @@ if role == CLIENT_ROLE:
                 destination_synchronized = twping_match.group(6);
                 destination_error        = twping_match.group(7);
                 ttl                      = twping_match.group(8);
-            
+
+            #collect rtt data
+            rtt = (float(twping_match.group(13)) - float(twping_match.group(2))) / pow(2, 32)
+            rtts.append(rtt)
+
+            rt = {
+                'seq': int(seq_number) + 1,
+                'length': int(rtt_length),
+                'ttl': int(ttl),
+                'rtt': pscheduler.timedelta_as_iso8601(datetime.timedelta(seconds=rtt))
+            }
+            if dest_hostname is not None:
+                rt['hostname'] = dest_hostname
+            if dest_ip is not None:
+                rt['ip'] = dest_ip
+            roundtrips.append(rt)
+
             #publish raw pings
             if raw_output:
                 #init packet object
@@ -268,6 +308,37 @@ if role == CLIENT_ROLE:
     if ('max-clock-error' in results):
         results['max-clock-error'] = round(results['max-clock-error']/TIME_SCALE, CLOCK_ERROR_DIGITS)
     
+    #convert results for rtt schema
+    if input['test']['type'] == 'rtt':
+        rtt_results = {
+            'schema': 1,
+            'sent': results['packets-sent'],
+            'received': results['packets-received'],
+            'lost': results['packets-lost'],
+            'reorders': results['packets-reordered'],
+            'duplicates': results['packets-duplicated'],
+            'roundtrips': roundtrips
+        }
+        results = rtt_results
+
+        # calculate stats
+        results['loss'] = 0
+        if results['sent'] > 0:
+            results['loss'] = float(results['sent']-results['received'])/float(results['sent'])
+
+        if len(rtts) > 0:
+            rtts.sort()
+            results['min'] = pscheduler.timedelta_as_iso8601(datetime.timedelta(seconds=rtts[0]))
+            results['max'] = pscheduler.timedelta_as_iso8601(datetime.timedelta(seconds=rtts[-1]))
+
+            mean = sum(rtts) / len(rtts)
+            results['mean'] = pscheduler.timedelta_as_iso8601(datetime.timedelta(seconds=mean))
+
+            stddev = 0.0
+            if len(rtts) > 1:
+                stddev = math.sqrt(sum((rtt-mean)**2 for rtt in rtts) / (len(rtts) - 1))
+            results['stddev'] = pscheduler.timedelta_as_iso8601(datetime.timedelta(seconds=stddev))
+
     results['succeeded'] = True
 elif role == SERVER_ROLE:
 #######


### PR DESCRIPTION
Allow twping tool to produce both ``latency`` and ``rtt`` type results.