### PR TITLE
Remove receiver-throughput-bits to avoid breaking 4.0 systems during …

### DIFF
--- a/pscheduler-test-throughput/throughput/throughput_utils.py
+++ b/pscheduler-test-throughput/throughput/throughput_utils.py
@@ -25,10 +25,6 @@ def format_stream_output(stream_list, udp=False, summary=False):
 
         if not summary:
             output += "{0:<15}".format("Current Window")
-
-    if summary and stream_list[0].has_key("receiver-throughput-bits"):
-        output += "{0:<20}".format("Receiver Throughput")
-
     output += "\n"
 
     for block in stream_list:
@@ -85,10 +81,6 @@ def format_stream_output(stream_list, udp=False, summary=False):
 
                 output += tcp_window
 
-        if block.has_key("receiver-throughput-bits"):
-            formatted_receiver_throughput = format_si(block["receiver-throughput-bits"])
-            formatted_receiver_throughput += "bps"
-            output += "{0:<20}".format(formatted_receiver_throughput)
 
         jitter = block.get('jitter')
         if jitter != None:

--- a/pscheduler-test-throughput/throughput/validate.py
+++ b/pscheduler-test-throughput/throughput/validate.py
@@ -106,10 +106,6 @@ RESULT_SCHEMA = {
                     "description": "Summarized view of the overall sender throughput rate in bytes/second",
                     "type": "number"
                     },
-                "receiver-throughput-bits": {
-                    "description": "Summarized view of the overall receiver throughput rate in bits/second",
-                    "type": "number"
-                    },
                 "sent": {
                     "description": "Number of packets sent",
                     "type": ["integer", "null"]

--- a/pscheduler-tool-iperf3/iperf3/iperf3_parser.py
+++ b/pscheduler-tool-iperf3/iperf3/iperf3_parser.py
@@ -70,10 +70,6 @@ def parse_output(lines):
 
     renamed_summary = rename_json(summary)
 
-    if sum_end.has_key("sum_received"):
-        received_summary = rename_json(sum_end["sum_received"])
-        renamed_summary["receiver-throughput-bits"] = received_summary["throughput-bits"]
-
     # kind of like above, the streams summary is in a different key
     # json schema does not require, so ignore if not provided
     sum_streams = sum_end.get('streams', [])


### PR DESCRIPTION
…reverse tests.  See #639