### PR TITLE
Mere 1.1.1 release code into master

### DIFF
--- a/pscheduler-account/pscheduler-account.spec
+++ b/pscheduler-account/pscheduler-account.spec
@@ -4,7 +4,7 @@
 
 Name:		pscheduler-account
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Account for pScheduler
 BuildArch:	noarch

--- a/pscheduler-account/pscheduler-account.spec
+++ b/pscheduler-account/pscheduler-account.spec
@@ -3,7 +3,7 @@
 #
 
 Name:		pscheduler-account
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Account for pScheduler

--- a/pscheduler-archiver-bitbucket/pscheduler-archiver-bitbucket.spec
+++ b/pscheduler-archiver-bitbucket/pscheduler-archiver-bitbucket.spec
@@ -4,7 +4,7 @@
 
 %define short	bitbucket
 Name:		pscheduler-archiver-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Bitbucket archiver class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 
 BuildRequires:	pscheduler-rpm
 

--- a/pscheduler-archiver-bitbucket/pscheduler-archiver-bitbucket.spec
+++ b/pscheduler-archiver-bitbucket/pscheduler-archiver-bitbucket.spec
@@ -5,7 +5,7 @@
 %define short	bitbucket
 Name:		pscheduler-archiver-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Bitbucket archiver class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-archiver-esmond/pscheduler-archiver-esmond.spec
+++ b/pscheduler-archiver-esmond/pscheduler-archiver-esmond.spec
@@ -4,7 +4,7 @@
 
 %define short	esmond
 Name:		pscheduler-archiver-esmond
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Esmond archiver class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 Requires:	python-requests
 Requires:	python-memcached
 Requires:	memcached

--- a/pscheduler-archiver-esmond/pscheduler-archiver-esmond.spec
+++ b/pscheduler-archiver-esmond/pscheduler-archiver-esmond.spec
@@ -5,7 +5,7 @@
 %define short	esmond
 Name:		pscheduler-archiver-esmond
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Esmond archiver class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-archiver-failer/pscheduler-archiver-failer.spec
+++ b/pscheduler-archiver-failer/pscheduler-archiver-failer.spec
@@ -4,7 +4,7 @@
 
 %define short	failer
 Name:		pscheduler-archiver-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Sometimes-failing archiver class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 
 BuildRequires:	pscheduler-rpm
 

--- a/pscheduler-archiver-failer/pscheduler-archiver-failer.spec
+++ b/pscheduler-archiver-failer/pscheduler-archiver-failer.spec
@@ -5,7 +5,7 @@
 %define short	failer
 Name:		pscheduler-archiver-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Sometimes-failing archiver class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-archiver-http/pscheduler-archiver-http.spec
+++ b/pscheduler-archiver-http/pscheduler-archiver-http.spec
@@ -4,7 +4,7 @@
 
 %define short	http
 Name:		pscheduler-archiver-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	HTTP archiver class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 
 BuildRequires:	pscheduler-rpm
 

--- a/pscheduler-archiver-http/pscheduler-archiver-http.spec
+++ b/pscheduler-archiver-http/pscheduler-archiver-http.spec
@@ -5,7 +5,7 @@
 %define short	http
 Name:		pscheduler-archiver-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	HTTP archiver class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-archiver-rabbitmq/pscheduler-archiver-rabbitmq.spec
+++ b/pscheduler-archiver-rabbitmq/pscheduler-archiver-rabbitmq.spec
@@ -5,7 +5,7 @@
 %define short	rabbitmq
 Name:		pscheduler-archiver-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	RabbitMQ archiver class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-archiver-rabbitmq/pscheduler-archiver-rabbitmq.spec
+++ b/pscheduler-archiver-rabbitmq/pscheduler-archiver-rabbitmq.spec
@@ -4,7 +4,7 @@
 
 %define short	rabbitmq
 Name:		pscheduler-archiver-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	RabbitMQ archiver class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 
 # Note that this doesn't get used since we're supplying our own 0.10.0
 # as a stopgap.

--- a/pscheduler-archiver-snmptrap/pscheduler-archiver-snmptrap.spec
+++ b/pscheduler-archiver-snmptrap/pscheduler-archiver-snmptrap.spec
@@ -5,7 +5,7 @@
 %define short	snmptrap
 Name:		pscheduler-archiver-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	snmptrap archiver class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-archiver-snmptrap/pscheduler-archiver-snmptrap.spec
+++ b/pscheduler-archiver-snmptrap/pscheduler-archiver-snmptrap.spec
@@ -4,7 +4,7 @@
 
 %define short	snmptrap
 Name:		pscheduler-archiver-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	snmptrap archiver class for pScheduler

--- a/pscheduler-archiver-syslog/pscheduler-archiver-syslog.spec
+++ b/pscheduler-archiver-syslog/pscheduler-archiver-syslog.spec
@@ -5,7 +5,7 @@
 %define short	syslog
 Name:		pscheduler-archiver-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Syslog archiver class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-archiver-syslog/pscheduler-archiver-syslog.spec
+++ b/pscheduler-archiver-syslog/pscheduler-archiver-syslog.spec
@@ -4,7 +4,7 @@
 
 %define short	syslog
 Name:		pscheduler-archiver-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Syslog archiver class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 
 BuildRequires:	pscheduler-rpm
 

--- a/pscheduler-bundle-extras/pscheduler-bundle-extras.spec-top
+++ b/pscheduler-bundle-extras/pscheduler-bundle-extras.spec-top
@@ -3,7 +3,7 @@
 #
 
 Name:		pscheduler-bundle-extras
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Extras pScheduler Bundle

--- a/pscheduler-bundle-extras/pscheduler-bundle-extras.spec-top
+++ b/pscheduler-bundle-extras/pscheduler-bundle-extras.spec-top
@@ -4,7 +4,7 @@
 
 Name:		pscheduler-bundle-extras
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Extras pScheduler Bundle
 BuildArch:	noarch

--- a/pscheduler-bundle-full/pscheduler-bundle-full.spec-top
+++ b/pscheduler-bundle-full/pscheduler-bundle-full.spec-top
@@ -4,7 +4,7 @@
 
 Name:		pscheduler-bundle-full
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Full pScheduler Bundle
 BuildArch:	noarch

--- a/pscheduler-bundle-full/pscheduler-bundle-full.spec-top
+++ b/pscheduler-bundle-full/pscheduler-bundle-full.spec-top
@@ -3,7 +3,7 @@
 #
 
 Name:		pscheduler-bundle-full
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Full pScheduler Bundle

--- a/pscheduler-context-changefail/pscheduler-context-changefail.spec
+++ b/pscheduler-context-changefail/pscheduler-context-changefail.spec
@@ -5,7 +5,7 @@
 %define short	changefail
 Name:		pscheduler-context-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Always-failing context changer class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-context-changefail/pscheduler-context-changefail.spec
+++ b/pscheduler-context-changefail/pscheduler-context-changefail.spec
@@ -4,7 +4,7 @@
 
 %define short	changefail
 Name:		pscheduler-context-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Always-failing context changer class for pScheduler

--- a/pscheduler-context-changenothing/pscheduler-context-changenothing.spec
+++ b/pscheduler-context-changenothing/pscheduler-context-changenothing.spec
@@ -4,7 +4,7 @@
 
 %define short	changenothing
 Name:		pscheduler-context-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Null context changer class for pScheduler

--- a/pscheduler-context-changenothing/pscheduler-context-changenothing.spec
+++ b/pscheduler-context-changenothing/pscheduler-context-changenothing.spec
@@ -5,7 +5,7 @@
 %define short	changenothing
 Name:		pscheduler-context-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Null context changer class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-context-linuxnns/pscheduler-context-linuxnns.spec
+++ b/pscheduler-context-linuxnns/pscheduler-context-linuxnns.spec
@@ -8,7 +8,7 @@
 
 %define short	linuxnns
 Name:		pscheduler-context-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Linux network namespace context changer for pScheduler

--- a/pscheduler-context-linuxnns/pscheduler-context-linuxnns.spec
+++ b/pscheduler-context-linuxnns/pscheduler-context-linuxnns.spec
@@ -9,7 +9,7 @@
 %define short	linuxnns
 Name:		pscheduler-context-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Linux network namespace context changer for pScheduler
 BuildArch:	noarch

--- a/pscheduler-core/pscheduler-core.spec
+++ b/pscheduler-core/pscheduler-core.spec
@@ -4,7 +4,7 @@
 
 Name:		pscheduler-core
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	pScheduler Core Programs
 BuildArch:	noarch

--- a/pscheduler-core/pscheduler-core.spec
+++ b/pscheduler-core/pscheduler-core.spec
@@ -3,7 +3,7 @@
 #
 
 Name:		pscheduler-core
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	pScheduler Core Programs

--- a/pscheduler-core/pscheduler-core/task
+++ b/pscheduler-core/pscheduler-core/task
@@ -277,7 +277,7 @@ verbose = (not options.quiet) \
     and (out_format == "text/plain") 
 
 # TODO: Tie this to the options.
-log = pscheduler.Log(verbose=verbose, debug=options.debug, quiet=True)
+log = pscheduler.Log(verbose=verbose, debug=options.debug, quiet=True, propagate=True)
 
 # Decide who assists us.
 

--- a/pscheduler-core/pscheduler-core/watch
+++ b/pscheduler-core/pscheduler-core/watch
@@ -97,7 +97,7 @@ if not pscheduler.api_is_task(task_url):
 verbose = (not options.quiet) and (out_format == "text/plain")
 
 
-log = pscheduler.Log(verbose=verbose, debug=options.debug, quiet=True)
+log = pscheduler.Log(verbose=verbose, debug=options.debug, quiet=True, propagate=True)
 
 
 # Get the task with details and find out its class.

--- a/pscheduler-docs/pscheduler-docs.spec
+++ b/pscheduler-docs/pscheduler-docs.spec
@@ -4,7 +4,7 @@
 
 Name:		pscheduler-docs
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	pScheduler documentation and samples
 

--- a/pscheduler-docs/pscheduler-docs.spec
+++ b/pscheduler-docs/pscheduler-docs.spec
@@ -3,7 +3,7 @@
 #
 
 Name:		pscheduler-docs
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	pScheduler documentation and samples

--- a/pscheduler-jq-library/pscheduler-jq-library.spec
+++ b/pscheduler-jq-library/pscheduler-jq-library.spec
@@ -3,7 +3,7 @@
 #
 
 Name:		pscheduler-jq-library
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Library of JQ functions for pScheduler

--- a/pscheduler-jq-library/pscheduler-jq-library.spec
+++ b/pscheduler-jq-library/pscheduler-jq-library.spec
@@ -4,7 +4,7 @@
 
 Name:		pscheduler-jq-library
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Library of JQ functions for pScheduler
 BuildArch:	noarch

--- a/pscheduler-rpm/pscheduler-rpm.spec
+++ b/pscheduler-rpm/pscheduler-rpm.spec
@@ -3,7 +3,7 @@
 #
 
 Name:		pscheduler-rpm
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Macros for use by pScheduler RPM specs

--- a/pscheduler-rpm/pscheduler-rpm.spec
+++ b/pscheduler-rpm/pscheduler-rpm.spec
@@ -4,7 +4,7 @@
 
 Name:		pscheduler-rpm
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Macros for use by pScheduler RPM specs
 BuildArch:	noarch

--- a/pscheduler-server/pscheduler-server.spec
+++ b/pscheduler-server/pscheduler-server.spec
@@ -7,7 +7,7 @@
 # init scripts function just fine.
 
 Name:		pscheduler-server
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	pScheduler Server

--- a/pscheduler-server/pscheduler-server.spec
+++ b/pscheduler-server/pscheduler-server.spec
@@ -8,7 +8,7 @@
 
 Name:		pscheduler-server
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	pScheduler Server
 BuildArch:	noarch

--- a/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/tests.py
+++ b/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/tests.py
@@ -146,12 +146,6 @@ def tests_name_participants(name):
 
     lead_bind = request.args.get("lead-bind")
 
-    # Validate the lead binding if there is one.
-    if lead_bind is not None \
-       and (pscheduler.address_interface(lead_bind) is None):
-        return bad_request("Lead bind '%s' is not on this host"
-                           % (lead_bind))
-
     if lead_bind is not None:
         env_add = {"PSCHEDULER_LEAD_BIND_HACK": lead_bind}
     else:

--- a/pscheduler-server/pscheduler-server/daemons/archiver.raw
+++ b/pscheduler-server/pscheduler-server/daemons/archiver.raw
@@ -113,7 +113,7 @@ if retry is None:
 retry = pscheduler.timedelta_as_seconds(retry)
 
 
-log = pscheduler.Log(verbose=options.verbose, debug=options.debug)
+log = pscheduler.Log(verbose=options.verbose, debug=options.debug, propagate=True)
 
 dsn = options.dsn
 

--- a/pscheduler-server/pscheduler-server/daemons/runner
+++ b/pscheduler-server/pscheduler-server/daemons/runner
@@ -73,7 +73,7 @@ if pscheduler.timedelta_as_seconds(refresh) == 0:
     opt_parser.error("Refresh interval must be calculable as seconds.")
 
 
-log = pscheduler.Log(verbose=options.verbose, debug=options.debug)
+log = pscheduler.Log(verbose=options.verbose, debug=options.debug, propagate=True)
 
 dsn = pscheduler.string_from_file(options.dsn)
 

--- a/pscheduler-server/pscheduler-server/daemons/scheduler
+++ b/pscheduler-server/pscheduler-server/daemons/scheduler
@@ -30,7 +30,7 @@ opt_parser.add_option("--daemon",
 opt_parser.add_option("--pid-file",
                       help="Location of PID file",
                       action="store", type="string", dest="pidfile",
-                      default=None)
+                      default="/dev/null")
 
 # Program options
 
@@ -95,7 +95,7 @@ timeout = pscheduler.timedelta_as_seconds(timeout_td)
 
 
 
-log = pscheduler.Log(verbose=options.verbose, debug=options.debug)
+log = pscheduler.Log(verbose=options.verbose, debug=options.debug, propagate=True)
 
 dsn = options.dsn
 

--- a/pscheduler-server/pscheduler-server/daemons/ticker
+++ b/pscheduler-server/pscheduler-server/daemons/ticker
@@ -41,8 +41,8 @@ opt_parser.add_option("-r", "--retry",
                       help="No-rows-returned retry interval (ISO8601)",
                       action="store", type="string", dest="retry",
                       default="PT15S")
-opt_parser.add_option("-v", "--verbose", action="store_true", dest="verbose")
-opt_parser.add_option("--debug", action="store_true", dest="debug")
+opt_parser.add_option("-v", "--verbose", action="store_true", dest="verbose", default=False)
+opt_parser.add_option("--debug", action="store_true", dest="debug", default=False)
 
 
 (options, args) = opt_parser.parse_args()
@@ -156,7 +156,4 @@ if options.daemon:
     with daemon.DaemonContext(pidfile=pidfile):
         pscheduler.safe_run(lambda: main_program())
 else:
-    if not options.verbose:
-        pscheduler.safe_run(lambda: main_program())
-    else:
-        main_program()
+    pscheduler.safe_run(lambda: main_program())

--- a/pscheduler-test-clock/pscheduler-test-clock.spec
+++ b/pscheduler-test-clock/pscheduler-test-clock.spec
@@ -4,7 +4,7 @@
 
 %define short	clock
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Clock test class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 Requires:	python-pscheduler >= 1.3
 Requires:	python-jsontemplate
 

--- a/pscheduler-test-clock/pscheduler-test-clock.spec
+++ b/pscheduler-test-clock/pscheduler-test-clock.spec
@@ -5,7 +5,7 @@
 %define short	clock
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Clock test class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-dns/pscheduler-test-dns.spec
+++ b/pscheduler-test-dns/pscheduler-test-dns.spec
@@ -5,7 +5,7 @@
 %define short	dns
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	DNS test for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-dns/pscheduler-test-dns.spec
+++ b/pscheduler-test-dns/pscheduler-test-dns.spec
@@ -4,7 +4,7 @@
 
 %define short	dns
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	DNS test for pScheduler

--- a/pscheduler-test-http/pscheduler-test-http.spec
+++ b/pscheduler-test-http/pscheduler-test-http.spec
@@ -5,7 +5,7 @@
 %define short	http
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	http test for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-http/pscheduler-test-http.spec
+++ b/pscheduler-test-http/pscheduler-test-http.spec
@@ -4,7 +4,7 @@
 
 %define short	http
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	http test for pScheduler

--- a/pscheduler-test-idle/pscheduler-test-idle.spec
+++ b/pscheduler-test-idle/pscheduler-test-idle.spec
@@ -5,7 +5,7 @@
 %define short	idle
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Idle test class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-idle/pscheduler-test-idle.spec
+++ b/pscheduler-test-idle/pscheduler-test-idle.spec
@@ -4,7 +4,7 @@
 
 %define short	idle
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Idle test class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 Requires:	python-pscheduler
 
 BuildRequires:	pscheduler-rpm

--- a/pscheduler-test-idlebgm/pscheduler-test-idlebgm.spec
+++ b/pscheduler-test-idlebgm/pscheduler-test-idlebgm.spec
@@ -5,7 +5,7 @@
 %define short	idlebgm
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Idle Background-Multi test class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-idlebgm/pscheduler-test-idlebgm.spec
+++ b/pscheduler-test-idlebgm/pscheduler-test-idlebgm.spec
@@ -4,7 +4,7 @@
 
 %define short	idlebgm
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Idle Background-Multi test class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 Requires:	python-pscheduler
 
 BuildRequires:	pscheduler-rpm

--- a/pscheduler-test-idleex/pscheduler-test-idleex.spec
+++ b/pscheduler-test-idleex/pscheduler-test-idleex.spec
@@ -4,7 +4,7 @@
 
 %define short	idleex
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Idle Exclusive test class for pScheduler

--- a/pscheduler-test-idleex/pscheduler-test-idleex.spec
+++ b/pscheduler-test-idleex/pscheduler-test-idleex.spec
@@ -5,7 +5,7 @@
 %define short	idleex
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Idle Exclusive test class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-latency/pscheduler-test-latency.spec
+++ b/pscheduler-test-latency/pscheduler-test-latency.spec
@@ -4,7 +4,7 @@
 
 %define short	latency
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Latency test class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 Requires:	python-pscheduler
 Requires:	python-jsontemplate
 

--- a/pscheduler-test-latency/pscheduler-test-latency.spec
+++ b/pscheduler-test-latency/pscheduler-test-latency.spec
@@ -5,7 +5,7 @@
 %define short	latency
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Latency test class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-latencybg/pscheduler-test-latencybg.spec
+++ b/pscheduler-test-latencybg/pscheduler-test-latencybg.spec
@@ -4,7 +4,7 @@
 
 %define short	latencybg
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Latency Background test class for pScheduler

--- a/pscheduler-test-latencybg/pscheduler-test-latencybg.spec
+++ b/pscheduler-test-latencybg/pscheduler-test-latencybg.spec
@@ -5,7 +5,7 @@
 %define short	latencybg
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Latency Background test class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-rtt/pscheduler-test-rtt.spec
+++ b/pscheduler-test-rtt/pscheduler-test-rtt.spec
@@ -4,7 +4,7 @@
 
 %define short	rtt
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Round trip time test class for pScheduler

--- a/pscheduler-test-rtt/pscheduler-test-rtt.spec
+++ b/pscheduler-test-rtt/pscheduler-test-rtt.spec
@@ -5,7 +5,7 @@
 %define short	rtt
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Round trip time test class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-rtt/rtt/participants
+++ b/pscheduler-test-rtt/rtt/participants
@@ -49,7 +49,8 @@ if has[source]["pscheduler"]:
 elif has[destination]["pscheduler"]:
     participants = [ destination ]
 else:
-    pscheduler.fail("Neither the source nor destination is running pScheduler.")
+    #if backward compatibility hacks failed, proceed normally
+    participants = [ source ]
 ######################################################################
 
 result = { "participants": participants }

--- a/pscheduler-test-simplestream/pscheduler-test-simplestream.spec
+++ b/pscheduler-test-simplestream/pscheduler-test-simplestream.spec
@@ -5,7 +5,7 @@
 %define short	simplestream
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Simplestream test class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-simplestream/pscheduler-test-simplestream.spec
+++ b/pscheduler-test-simplestream/pscheduler-test-simplestream.spec
@@ -4,7 +4,7 @@
 
 %define short	simplestream
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Simplestream test class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 Requires:	python-pscheduler > 1.3.2.6.0
 Requires:	python-jsontemplate
 

--- a/pscheduler-test-snmpget/pscheduler-test-snmpget.spec
+++ b/pscheduler-test-snmpget/pscheduler-test-snmpget.spec
@@ -7,7 +7,7 @@
 %define short	snmpget
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	snmpget test for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-snmpget/pscheduler-test-snmpget.spec
+++ b/pscheduler-test-snmpget/pscheduler-test-snmpget.spec
@@ -6,7 +6,7 @@
 
 %define short	snmpget
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	snmpget test for pScheduler

--- a/pscheduler-test-snmpgetbgm/pscheduler-test-snmpgetbgm.spec
+++ b/pscheduler-test-snmpgetbgm/pscheduler-test-snmpgetbgm.spec
@@ -5,7 +5,7 @@
 %define short	snmpgetbgm
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	snmpgetbgm test for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-snmpgetbgm/pscheduler-test-snmpgetbgm.spec
+++ b/pscheduler-test-snmpgetbgm/pscheduler-test-snmpgetbgm.spec
@@ -4,7 +4,7 @@
 
 %define short	snmpgetbgm
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	snmpgetbgm test for pScheduler

--- a/pscheduler-test-snmpset/pscheduler-test-snmpset.spec
+++ b/pscheduler-test-snmpset/pscheduler-test-snmpset.spec
@@ -4,7 +4,7 @@
 
 %define short	snmpset
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	snmpset test for pScheduler

--- a/pscheduler-test-snmpset/pscheduler-test-snmpset.spec
+++ b/pscheduler-test-snmpset/pscheduler-test-snmpset.spec
@@ -5,7 +5,7 @@
 %define short	snmpset
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	snmpset test for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-throughput/pscheduler-test-throughput.spec
+++ b/pscheduler-test-throughput/pscheduler-test-throughput.spec
@@ -4,7 +4,7 @@
 
 %define short	throughput
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Throughput test class for pScheduler

--- a/pscheduler-test-throughput/pscheduler-test-throughput.spec
+++ b/pscheduler-test-throughput/pscheduler-test-throughput.spec
@@ -5,7 +5,7 @@
 %define short	throughput
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Throughput test class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-throughput/throughput/participants
+++ b/pscheduler-test-throughput/throughput/participants
@@ -51,13 +51,9 @@ if src_has_psc and single_ended:
     participants = [ source ]
 elif src_has_psc and dst_has_psc:
     participants = [ source, destination ]
-elif src_has_psc:
-    if not has[destination]["bwctl"]:
-        pscheduler.fail("Can't find pScheduler or BWCTL on %s" % destination)
+elif src_has_psc and has[destination]["bwctl"]:
     participants = [ source ]
-elif dst_has_psc:
-    if not has[source]["bwctl"]:
-        pscheduler.fail("Can't find pScheduler or BWCTL on %s " % source)
+elif dst_has_psc and has[source]["bwctl"]:
     participants = [ destination ]
 else: 
     #if backward compatibility hacks failed, proceed normally

--- a/pscheduler-test-throughput/throughput/participants
+++ b/pscheduler-test-throughput/throughput/participants
@@ -60,7 +60,8 @@ elif dst_has_psc:
         pscheduler.fail("Can't find pScheduler or BWCTL on %s " % source)
     participants = [ destination ]
 else: 
-    pscheduler.fail("Neither the source nor destination is running pScheduler.")
+    #if backward compatibility hacks failed, proceed normally
+    participants = [ source, destination ]
 
 
 ######################################################################

--- a/pscheduler-test-trace/pscheduler-test-trace.spec
+++ b/pscheduler-test-trace/pscheduler-test-trace.spec
@@ -4,7 +4,7 @@
 
 %define short	trace
 Name:		pscheduler-test-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Simplestream test class for pScheduler
@@ -17,7 +17,7 @@ Source0:	%{short}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
 
-Requires:	pscheduler-server >= 1.1
+Requires:	pscheduler-server >= 1.1.1
 Requires:	python-pscheduler >= 1.3
 Requires:	python-jsontemplate
 

--- a/pscheduler-test-trace/pscheduler-test-trace.spec
+++ b/pscheduler-test-trace/pscheduler-test-trace.spec
@@ -5,7 +5,7 @@
 %define short	trace
 Name:		pscheduler-test-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Simplestream test class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-test-trace/trace/participants
+++ b/pscheduler-test-trace/trace/participants
@@ -46,7 +46,8 @@ if source is None or has[source]["pscheduler"]:
 elif has[destination]["pscheduler"]:
     participants = [ destination ]
 else:
-    pscheduler.fail("Neither the source nor destination is running pScheduler.")
+    #if backward compatibility hacks failed, proceed normally
+    participants = [ source ]
 ######################################################################
 
 result = { "participants": participants }

--- a/pscheduler-tool-bwctliperf2/pscheduler-tool-bwctliperf2.spec
+++ b/pscheduler-tool-bwctliperf2/pscheduler-tool-bwctliperf2.spec
@@ -4,7 +4,7 @@
 
 %define short	bwctliperf2
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	bwctliperf2 tool class for pScheduler

--- a/pscheduler-tool-bwctliperf2/pscheduler-tool-bwctliperf2.spec
+++ b/pscheduler-tool-bwctliperf2/pscheduler-tool-bwctliperf2.spec
@@ -5,7 +5,7 @@
 %define short	bwctliperf2
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	bwctliperf2 tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-bwctliperf3/pscheduler-tool-bwctliperf3.spec
+++ b/pscheduler-tool-bwctliperf3/pscheduler-tool-bwctliperf3.spec
@@ -5,7 +5,7 @@
 %define short	bwctliperf3
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	BWCTL iperf3 tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-bwctliperf3/pscheduler-tool-bwctliperf3.spec
+++ b/pscheduler-tool-bwctliperf3/pscheduler-tool-bwctliperf3.spec
@@ -4,7 +4,7 @@
 
 %define short	bwctliperf3
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	BWCTL iperf3 tool class for pScheduler

--- a/pscheduler-tool-bwctlping/pscheduler-tool-bwctlping.spec
+++ b/pscheduler-tool-bwctlping/pscheduler-tool-bwctlping.spec
@@ -5,7 +5,7 @@
 %define short	bwctlping
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	pScheduler BWCTL Ping Tool
 BuildArch:	noarch

--- a/pscheduler-tool-bwctlping/pscheduler-tool-bwctlping.spec
+++ b/pscheduler-tool-bwctlping/pscheduler-tool-bwctlping.spec
@@ -4,7 +4,7 @@
 
 %define short	bwctlping
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	pScheduler BWCTL Ping Tool

--- a/pscheduler-tool-bwctltracepath/pscheduler-tool-bwctltracepath.spec
+++ b/pscheduler-tool-bwctltracepath/pscheduler-tool-bwctltracepath.spec
@@ -5,7 +5,7 @@
 %define short	bwctltracepath
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	pScheduler BWCTL Tracepath Tool
 BuildArch:	noarch

--- a/pscheduler-tool-bwctltracepath/pscheduler-tool-bwctltracepath.spec
+++ b/pscheduler-tool-bwctltracepath/pscheduler-tool-bwctltracepath.spec
@@ -4,7 +4,7 @@
 
 %define short	bwctltracepath
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	pScheduler BWCTL Tracepath Tool

--- a/pscheduler-tool-bwctltraceroute/pscheduler-tool-bwctltraceroute.spec
+++ b/pscheduler-tool-bwctltraceroute/pscheduler-tool-bwctltraceroute.spec
@@ -5,7 +5,7 @@
 %define short	bwctltraceroute
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	pScheduler BWCTL Traceroute Tool
 BuildArch:	noarch

--- a/pscheduler-tool-bwctltraceroute/pscheduler-tool-bwctltraceroute.spec
+++ b/pscheduler-tool-bwctltraceroute/pscheduler-tool-bwctltraceroute.spec
@@ -4,7 +4,7 @@
 
 %define short	bwctltraceroute
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	pScheduler BWCTL Traceroute Tool

--- a/pscheduler-tool-dnspy/pscheduler-tool-dnspy.spec
+++ b/pscheduler-tool-dnspy/pscheduler-tool-dnspy.spec
@@ -5,7 +5,7 @@
 %define short	dnspy
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	DNS tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-dnspy/pscheduler-tool-dnspy.spec
+++ b/pscheduler-tool-dnspy/pscheduler-tool-dnspy.spec
@@ -4,7 +4,7 @@
 
 %define short	dnspy
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	DNS tool class for pScheduler

--- a/pscheduler-tool-iperf2/pscheduler-tool-iperf2.spec
+++ b/pscheduler-tool-iperf2/pscheduler-tool-iperf2.spec
@@ -5,7 +5,7 @@
 %define short	iperf2
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	iperf2 tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-iperf2/pscheduler-tool-iperf2.spec
+++ b/pscheduler-tool-iperf2/pscheduler-tool-iperf2.spec
@@ -4,7 +4,7 @@
 
 %define short	iperf2
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	iperf2 tool class for pScheduler

--- a/pscheduler-tool-iperf3/pscheduler-tool-iperf3.spec
+++ b/pscheduler-tool-iperf3/pscheduler-tool-iperf3.spec
@@ -5,7 +5,7 @@
 %define short	iperf3
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	iperf3 tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-iperf3/pscheduler-tool-iperf3.spec
+++ b/pscheduler-tool-iperf3/pscheduler-tool-iperf3.spec
@@ -4,7 +4,7 @@
 
 %define short	iperf3
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	iperf3 tool class for pScheduler

--- a/pscheduler-tool-net-snmp-set/pscheduler-tool-net-snmp-set.spec
+++ b/pscheduler-tool-net-snmp-set/pscheduler-tool-net-snmp-set.spec
@@ -5,7 +5,7 @@
 %define short	net-snmp-set
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	snmpset tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-net-snmp-set/pscheduler-tool-net-snmp-set.spec
+++ b/pscheduler-tool-net-snmp-set/pscheduler-tool-net-snmp-set.spec
@@ -4,7 +4,7 @@
 
 %define short	net-snmp-set
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	snmpset tool class for pScheduler

--- a/pscheduler-tool-nuttcp/pscheduler-tool-nuttcp.spec
+++ b/pscheduler-tool-nuttcp/pscheduler-tool-nuttcp.spec
@@ -4,7 +4,7 @@
 
 %define short	nuttcp
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	nuttcp tool class for pScheduler

--- a/pscheduler-tool-nuttcp/pscheduler-tool-nuttcp.spec
+++ b/pscheduler-tool-nuttcp/pscheduler-tool-nuttcp.spec
@@ -5,7 +5,7 @@
 %define short	nuttcp
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	nuttcp tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-owping/pscheduler-tool-owping.spec
+++ b/pscheduler-tool-owping/pscheduler-tool-owping.spec
@@ -4,7 +4,7 @@
 
 %define short	owping
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	owping tool class for pScheduler

--- a/pscheduler-tool-owping/pscheduler-tool-owping.spec
+++ b/pscheduler-tool-owping/pscheduler-tool-owping.spec
@@ -5,7 +5,7 @@
 %define short	owping
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	owping tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-paris-traceroute/pscheduler-tool-paris-traceroute.spec
+++ b/pscheduler-tool-paris-traceroute/pscheduler-tool-paris-traceroute.spec
@@ -4,7 +4,7 @@
 
 %define short	paris-traceroute
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	pScheduler Paris Traceroute Tool

--- a/pscheduler-tool-paris-traceroute/pscheduler-tool-paris-traceroute.spec
+++ b/pscheduler-tool-paris-traceroute/pscheduler-tool-paris-traceroute.spec
@@ -5,7 +5,7 @@
 %define short	paris-traceroute
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	pScheduler Paris Traceroute Tool
 BuildArch:	noarch

--- a/pscheduler-tool-ping/pscheduler-tool-ping.spec
+++ b/pscheduler-tool-ping/pscheduler-tool-ping.spec
@@ -4,7 +4,7 @@
 
 %define short	ping
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	pScheduler Ping Tool

--- a/pscheduler-tool-ping/pscheduler-tool-ping.spec
+++ b/pscheduler-tool-ping/pscheduler-tool-ping.spec
@@ -5,7 +5,7 @@
 %define short	ping
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	pScheduler Ping Tool
 BuildArch:	noarch

--- a/pscheduler-tool-powstream/pscheduler-tool-powstream.spec
+++ b/pscheduler-tool-powstream/pscheduler-tool-powstream.spec
@@ -7,7 +7,7 @@
 
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	powstream tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-powstream/pscheduler-tool-powstream.spec
+++ b/pscheduler-tool-powstream/pscheduler-tool-powstream.spec
@@ -6,7 +6,7 @@
 %define resultdir	%{_pscheduler_tool_vardir}/%{short}
 
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	powstream tool class for pScheduler

--- a/pscheduler-tool-psclock/pscheduler-tool-psclock.spec
+++ b/pscheduler-tool-psclock/pscheduler-tool-psclock.spec
@@ -4,7 +4,7 @@
 
 %define short	psclock
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Clock tester tool class for pScheduler

--- a/pscheduler-tool-psclock/pscheduler-tool-psclock.spec
+++ b/pscheduler-tool-psclock/pscheduler-tool-psclock.spec
@@ -5,7 +5,7 @@
 %define short	psclock
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Clock tester tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-psurl/pscheduler-tool-psurl.spec
+++ b/pscheduler-tool-psurl/pscheduler-tool-psurl.spec
@@ -5,7 +5,7 @@
 %define short	psurl
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	psurl tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-psurl/pscheduler-tool-psurl.spec
+++ b/pscheduler-tool-psurl/pscheduler-tool-psurl.spec
@@ -4,7 +4,7 @@
 
 %define short	psurl
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	psurl tool class for pScheduler

--- a/pscheduler-tool-pysnmp/pscheduler-tool-pysnmp.spec
+++ b/pscheduler-tool-pysnmp/pscheduler-tool-pysnmp.spec
@@ -4,7 +4,7 @@
 
 %define short	pysnmp
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	NET SNMP tool class for pScheduler

--- a/pscheduler-tool-pysnmp/pscheduler-tool-pysnmp.spec
+++ b/pscheduler-tool-pysnmp/pscheduler-tool-pysnmp.spec
@@ -5,7 +5,7 @@
 %define short	pysnmp
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	NET SNMP tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-simplestreamer/pscheduler-tool-simplestreamer.spec
+++ b/pscheduler-tool-simplestreamer/pscheduler-tool-simplestreamer.spec
@@ -5,7 +5,7 @@
 %define short	simplestreamer
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Simple Streamer tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-simplestreamer/pscheduler-tool-simplestreamer.spec
+++ b/pscheduler-tool-simplestreamer/pscheduler-tool-simplestreamer.spec
@@ -4,7 +4,7 @@
 
 %define short	simplestreamer
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Simple Streamer tool class for pScheduler

--- a/pscheduler-tool-sleep/pscheduler-tool-sleep.spec
+++ b/pscheduler-tool-sleep/pscheduler-tool-sleep.spec
@@ -5,7 +5,7 @@
 %define short	sleep
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Sleep tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-sleep/pscheduler-tool-sleep.spec
+++ b/pscheduler-tool-sleep/pscheduler-tool-sleep.spec
@@ -4,7 +4,7 @@
 
 %define short	sleep
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Sleep tool class for pScheduler

--- a/pscheduler-tool-sleepbgm/pscheduler-tool-sleepbgm.spec
+++ b/pscheduler-tool-sleepbgm/pscheduler-tool-sleepbgm.spec
@@ -4,7 +4,7 @@
 
 %define short	sleepbgm
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Background Sleep tool class for pScheduler

--- a/pscheduler-tool-sleepbgm/pscheduler-tool-sleepbgm.spec
+++ b/pscheduler-tool-sleepbgm/pscheduler-tool-sleepbgm.spec
@@ -5,7 +5,7 @@
 %define short	sleepbgm
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Background Sleep tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-snooze/pscheduler-tool-snooze.spec
+++ b/pscheduler-tool-snooze/pscheduler-tool-snooze.spec
@@ -5,7 +5,7 @@
 %define short	snooze
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	Sleep tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-snooze/pscheduler-tool-snooze.spec
+++ b/pscheduler-tool-snooze/pscheduler-tool-snooze.spec
@@ -4,7 +4,7 @@
 
 %define short	snooze
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	Sleep tool class for pScheduler

--- a/pscheduler-tool-tracepath/pscheduler-tool-tracepath.spec
+++ b/pscheduler-tool-tracepath/pscheduler-tool-tracepath.spec
@@ -4,7 +4,7 @@
 
 %define short	tracepath
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	pScheduler Tracepath Tool

--- a/pscheduler-tool-tracepath/pscheduler-tool-tracepath.spec
+++ b/pscheduler-tool-tracepath/pscheduler-tool-tracepath.spec
@@ -5,7 +5,7 @@
 %define short	tracepath
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	pScheduler Tracepath Tool
 BuildArch:	noarch

--- a/pscheduler-tool-traceroute/pscheduler-tool-traceroute.spec
+++ b/pscheduler-tool-traceroute/pscheduler-tool-traceroute.spec
@@ -4,7 +4,7 @@
 
 %define short	traceroute
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	pScheduler Traceroute Tool

--- a/pscheduler-tool-traceroute/pscheduler-tool-traceroute.spec
+++ b/pscheduler-tool-traceroute/pscheduler-tool-traceroute.spec
@@ -5,7 +5,7 @@
 %define short	traceroute
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	pScheduler Traceroute Tool
 BuildArch:	noarch

--- a/pscheduler-tool-twping/pscheduler-tool-twping.spec
+++ b/pscheduler-tool-twping/pscheduler-tool-twping.spec
@@ -5,7 +5,7 @@
 %define short	twping
 Name:		pscheduler-tool-%{short}
 Version:	1.1
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 
 Summary:	twping tool class for pScheduler
 BuildArch:	noarch

--- a/pscheduler-tool-twping/pscheduler-tool-twping.spec
+++ b/pscheduler-tool-twping/pscheduler-tool-twping.spec
@@ -4,7 +4,7 @@
 
 %define short	twping
 Name:		pscheduler-tool-%{short}
-Version:	1.1
+Version:	1.1.1
 Release:	1%{?dist}
 
 Summary:	twping tool class for pScheduler

--- a/python-pscheduler/pscheduler/pscheduler/log.py
+++ b/python-pscheduler/pscheduler/pscheduler/log.py
@@ -58,25 +58,36 @@ class Log():
     Sendig SIGUSR1 will force the log level to DEBUG.  Sending SIGUSR2
     will set it to whatever level was previously set.
 
-    If the 'propagate' parameter is True (which it is by default), the
-    logging state (level, forced debug, quiet) will be passed along to
-    any child process which instantiates a Log instance.  This happens
-    via the environment, so anything that scrubs it clean (e.g., sudo)
-    will cause this feaure not to function.
+    If the 'propagate' parameter is True, the logging state (level,
+    forced debug, quiet) will be passed along to any child process
+    which instantiates a Log instance.  This happens via the
+    environment, so anything that scrubs it clean (e.g., sudo) will
+    cause this feaure not to function.  Also note that if there is
+    more than one propagating logger present in a process, the
+    last-set group of parameters will be put into the environment.
     """
 
     def __syslog_handler_deinit(self):
         """
         Kill off the syslog handler; called when a log event fails.
         """
-        if self.syslog_handler is not None:
-            self.logger.removeHandler(self.syslog_handler)
-            self.syslog_handler = None
+
+        try:
+            if self.syslog_handler is not None:
+                self.logger.removeHandler(self.syslog_handler)
+                self.syslog_handler = None
+        except AttributeError:
+            # Don't care if it's not there.
+            pass
 
     def __syslog_handler_init(self):
         """
         Initialize the syslog handler if it hasn't been
         """
+
+        if not hasattr(self, "syslog_handler"):
+            self.syslog_handler = None
+
         if self.syslog_handler is None:
             try:
                 # TODO: /dev/log is Linux-specific.
@@ -100,7 +111,7 @@ class Log():
                  verbose=False,  # Log to stderr, too.
                  quiet=None,   # Don't log anything on startup  (See below)
                  signals=True,  # Enable debug on/off with SIGUSR1/SIGUSR2
-                 propagate=True  # Pass debug state on to child processes
+                 propagate=False  # Pass debug state on to child processes
                  ):
 
         #
@@ -121,7 +132,6 @@ class Log():
             level = DEBUG
 
         self.is_propagating = propagate
-        self.is_propagating = True
 
         # This prevents verbose() from choking on this being undefined.
         self.is_verbose = False
@@ -134,7 +144,7 @@ class Log():
 
         self.is_quiet = quiet
 
-        self.forced_debug = False
+        self.forced_debug = debug
 
         #
         # Inherit state from the environment
@@ -186,7 +196,7 @@ class Log():
         #
 
         self.verbose(verbose)
-        self.level(level)
+        self.level(level, save=True)
         self.set_debug(self.forced_debug)
         self.__update_env()
 
@@ -293,10 +303,6 @@ class Log():
 
     def set_debug(self, state):
         "Turn debugging on or off, remembering the last-set level"
-
-        if state == self.forced_debug:
-            self.debug("Debug signal ignored; already %sdebugging",
-                       "" if state else "not ")
 
         if state:
             self.level(DEBUG, save=False)

--- a/python-pscheduler/pscheduler/pscheduler/saferun.py
+++ b/python-pscheduler/pscheduler/pscheduler/saferun.py
@@ -5,6 +5,7 @@
 import os
 import pickle
 import pscheduler
+import resource
 import sys
 import time
 
@@ -112,6 +113,12 @@ def safe_run(function,
         'runs': runs
     }
     os.environ[STATE_VARIABLE] = pickle.dumps(to_pickle)
+
+    # Close all open FDs other than stdin/stdout/stderr so they don't
+    # get inherited by the exec'd process.
+    # PORT: Make sure this is portable to OS X and elsewhere
+    (file_max_soft, file_max_hard) = resource.getrlimit(resource.RLIMIT_NOFILE)
+    os.closerange(sys.stderr.fileno() + 1, file_max_soft)
 
     os.execvp(sys.argv[0], sys.argv)
 

--- a/python-pscheduler/python-pscheduler.spec
+++ b/python-pscheduler/python-pscheduler.spec
@@ -4,7 +4,7 @@
 
 %define short	pscheduler
 Name:		python-%{short}
-Version:	1.3.3
+Version:	1.3.4
 Release:	1%{?dist}
 Summary:	Utility functions for pScheduler
 BuildArch:	noarch

--- a/python-pscheduler/python-pscheduler.spec
+++ b/python-pscheduler/python-pscheduler.spec
@@ -5,7 +5,7 @@
 %define short	pscheduler
 Name:		python-%{short}
 Version:	1.3.3
-Release:	0.3.b1%{?dist}
+Release:	1%{?dist}
 Summary:	Utility functions for pScheduler
 BuildArch:	noarch
 License:        ASL 2.0	


### PR DESCRIPTION
This merges the 1.1.1 release code into master. Mainly just bumps version numbers in .spec files, though I see a few other changes that may need review.