### PR TITLE
Issue 693: Fixes histogram bucket sorting in latency test CLI output

### DIFF
--- a/pscheduler-test-latency/latency/result-format
+++ b/pscheduler-test-latency/latency/result-format
@@ -68,7 +68,7 @@ if stats.get('percentile-75', None) and stats.get('percentile-25', None):
 output += format_float("    Variance", stats.get('variance', None), units="ms")
 output += format_float("    Std Deviation", stats.get('standard-deviation', None), units="ms")
 output += "Histogram:\n"
-for owd_bucket in sorted(json.get('histogram-latency', {}).items()):
+for owd_bucket in sorted(json.get('histogram-latency', {}).items(), key=lambda k: float(k[0])):
     output += "    %s ms: %d packets\n" % (owd_bucket[0], owd_bucket[1])
     
 #Output TTL histogram
@@ -88,7 +88,7 @@ output += format_float("TTL 25th Percentile", ttl_stats.get('percentile-25', Non
 output += format_float("TTL 75th Percentile", ttl_stats.get('percentile-75', None))
 output += format_float("TTL 95th Percentile", ttl_stats.get('percentile-95', None))
 output += "Histogram:\n"
-for ttl_bucket in sorted(json.get('histogram-ttl', {}).items()):
+for ttl_bucket in sorted(json.get('histogram-ttl', {}).items(), key=lambda k: int(k[0])):
     output += "    %s: %d packets\n" % (ttl_bucket[0], ttl_bucket[1])
 
 #output raw packets if we have them


### PR DESCRIPTION
Simple fix to make sure histogram buckets are sorted numerically instead of alphabetically for text output of latency tests. 