### PR TITLE
Fixing issue found on tesbed where pscheduler-server RPM won't instal…

### DIFF
--- a/pscheduler-server/pscheduler-server.spec
+++ b/pscheduler-server/pscheduler-server.spec
@@ -8,7 +8,7 @@
 
 Name:		pscheduler-server
 Version:	1.1.5
-Release:	1%{?dist}
+Release:	2%{?dist}
 
 Summary:	pScheduler Server
 BuildArch:	noarch
@@ -284,7 +284,11 @@ make -C utilities \
 #
 if [ "$1" -eq 2 ]
 then
-    pscheduler internal service stop
+    for SERVICE in ticker runner archiver scheduler
+    do
+        NAME="pscheduler-${SERVICE}"
+        systemctl stop "${NAME}"
+    done
 fi
 
 #


### PR DESCRIPTION
…l due to scriptlet error. Problem was call to 'pscheduler internal service stop' before it was installed. Bumping relnumn but leaving version the same since this is just a RPM  spec change