### PR TITLE
Fixes Issue 812 where HTTP 2XX status codes above 200 are considered failed

### DIFF
--- a/python-pscheduler/pscheduler/pscheduler/psurl.py
+++ b/python-pscheduler/pscheduler/pscheduler/psurl.py
@@ -68,8 +68,9 @@ class PycURLRunner(object):
         finally:
             self.curl.close()
             self.buf.close()
-
-        if status != 200:
+            
+        #If status is outside the HTTP 2XX success  range
+        if status < 200 or status > 299:
             if throw:
                 raise URLException(text.strip())
             else:


### PR DESCRIPTION
Fixing issue in psurl where a HTTP request succeeds but returns a status code that is not 200, such as a 201. This change accepts anything in the HTTP success range of 200-299