### PR TITLE
Disable TLS host name checking in pycurl

### DIFF
--- a/python-pscheduler/pscheduler/pscheduler/psurl.py
+++ b/python-pscheduler/pscheduler/pscheduler/psurl.py
@@ -49,6 +49,7 @@ class PycURLRunner(object):
         if timeout is not None:
             self.curl.setopt(pycurl.TIMEOUT_MS, int(timeout * 1000.0))
 
+        self.curl.setopt(pycurl.SSL_VERIFYHOST, verify_keys)
         self.curl.setopt(pycurl.SSL_VERIFYPEER, verify_keys)
 
         self.buf = StringIO.StringIO()


### PR DESCRIPTION
$ pscheduler troubleshoot
Performing basic troubleshooting of localhost.

localhost:

  Measuring MTU... Failed.
SSL: certificate subject name (stretch) does not match target host name 'localhost'