### PR TITLE
Disabling all pscheduler-tool-bwctl* packages in Debian and Ubuntu

### DIFF
--- a/pscheduler-tool-bwctliperf2/debian/changelog
+++ b/pscheduler-tool-bwctliperf2/debian/changelog
@@ -1,8 +1,8 @@
 pscheduler-tool-bwctliperf2 (4.2.1~a1.0-1) perfsonar-4.2-snapshot; urgency=low
 
-  * New upstream version.
+  * Dummy package disabling all functionnality.
 
- -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Tue, 27 Aug 2019 17:33:18 +0000
+ -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Fri, 30 Aug 2019 16:37:51 +0000
 
 pscheduler-tool-bwctliperf2 (4.2.0-1) perfsonar-minor-staging; urgency=low
 

--- a/pscheduler-tool-bwctliperf2/debian/control
+++ b/pscheduler-tool-bwctliperf2/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: perfSONAR developers <debian@perfsonar.net>
 Uploaders: Antoine Delvaux <antoine.delvaux@man.poznan.pl>,
  Valentin Vidic <Valentin.Vidic@CARNet.hr>
-Build-Depends: debhelper (>= 9), python
+Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.6
 Homepage: https://github.com/perfsonar/pscheduler
 Vcs-Git: git://github.com/perfsonar/pscheduler
@@ -12,8 +12,7 @@ Vcs-Browser: https://github.com/perfsonar/pscheduler
 
 Package: pscheduler-tool-bwctliperf2
 Architecture: all
-Depends: ${misc:Depends}, python, python-pscheduler,
- pscheduler-server, pscheduler-test-throughput,
- python-ipaddr, iperf, bwctl-client, bwctl-server
-Description: pScheduler bwctliperf2 tool
+Depends: ${misc:Depends}, pscheduler-server, pscheduler-test-throughput
+Description: pScheduler bwctliperf2 tool (DISABLED)
  bwctliperf2 tool class for pScheduler
+ (DISABLED)

--- a/pscheduler-tool-bwctliperf3/debian/changelog
+++ b/pscheduler-tool-bwctliperf3/debian/changelog
@@ -1,8 +1,8 @@
 pscheduler-tool-bwctliperf3 (4.2.1~a1.0-1) perfsonar-4.2-snapshot; urgency=low
 
-  * New upstream version.
+  * Dummy package disabling all functionnality.
 
- -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Tue, 27 Aug 2019 17:33:18 +0000
+ -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Fri, 30 Aug 2019 16:37:51 +0000
 
 pscheduler-tool-bwctliperf3 (4.2.0-1) perfsonar-minor-staging; urgency=low
 

--- a/pscheduler-tool-bwctliperf3/debian/control
+++ b/pscheduler-tool-bwctliperf3/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: perfSONAR developers <debian@perfsonar.net>
 Uploaders: Antoine Delvaux <antoine.delvaux@man.poznan.pl>,
  Valentin Vidic <Valentin.Vidic@CARNet.hr>
-Build-Depends: debhelper (>= 9), python
+Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.6
 Homepage: https://github.com/perfsonar/pscheduler
 Vcs-Git: git://github.com/perfsonar/pscheduler
@@ -12,8 +12,7 @@ Vcs-Browser: https://github.com/perfsonar/pscheduler
 
 Package: pscheduler-tool-bwctliperf3
 Architecture: all
-Depends: ${misc:Depends}, python, python-pscheduler,
- pscheduler-server, pscheduler-test-throughput,
- python-ipaddr, iperf3, bwctl-client, bwctl-server
-Description: pScheduler bwctliperf3 tool
+Depends: ${misc:Depends}, pscheduler-server, pscheduler-test-throughput
+Description: pScheduler bwctliperf3 tool (DISABLED)
  bwctliperf3 tool class for pScheduler
+ (DISABLED)

--- a/pscheduler-tool-bwctlping/debian/changelog
+++ b/pscheduler-tool-bwctlping/debian/changelog
@@ -1,8 +1,8 @@
 pscheduler-tool-bwctlping (4.2.1~a1.0-1) perfsonar-4.2-snapshot; urgency=low
 
-  * New upstream version.
+  * Dummy package disabling all functionnality.
 
- -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Tue, 27 Aug 2019 17:33:18 +0000
+ -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Fri, 30 Aug 2019 16:37:51 +0000
 
 pscheduler-tool-bwctlping (4.2.0-1) perfsonar-minor-staging; urgency=low
 

--- a/pscheduler-tool-bwctlping/debian/control
+++ b/pscheduler-tool-bwctlping/debian/control
@@ -12,9 +12,7 @@ Vcs-Browser: https://github.com/perfsonar/pscheduler
 
 Package: pscheduler-tool-bwctlping
 Architecture: all
-Depends: ${misc:Depends}, python, python-pscheduler,
- pscheduler-server, pscheduler-test-rtt,
- python-ipaddr, python-icmperror, iputils-ping,
- bwctl-client, bwctl-server
-Description: pScheduler bwctlping tool
+Depends: ${misc:Depends}, pscheduler-server, pscheduler-test-rtt
+Description: pScheduler bwctlping tool (DISABLED)
  bwctlping tool class for pScheduler
+ (DISABLED)

--- a/pscheduler-tool-bwctltracepath/debian/changelog
+++ b/pscheduler-tool-bwctltracepath/debian/changelog
@@ -1,8 +1,8 @@
 pscheduler-tool-bwctltracepath (4.2.1~a1.0-1) perfsonar-4.2-snapshot; urgency=low
 
-  * New upstream version.
+  * Dummy package disabling all functionnality.
 
- -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Tue, 27 Aug 2019 17:33:18 +0000
+ -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Fri, 30 Aug 2019 16:37:51 +0000
 
 pscheduler-tool-bwctltracepath (4.2.0-1) perfsonar-minor-staging; urgency=low
 

--- a/pscheduler-tool-bwctltracepath/debian/control
+++ b/pscheduler-tool-bwctltracepath/debian/control
@@ -12,9 +12,7 @@ Vcs-Browser: https://github.com/perfsonar/pscheduler
 
 Package: pscheduler-tool-bwctltracepath
 Architecture: all
-Depends: ${misc:Depends}, python, python-pscheduler,
- pscheduler-server, pscheduler-test-trace,
- python-icmperror, iputils-tracepath,
- bwctl-client, bwctl-server
-Description: pScheduler bwctltracepath tool
+Depends: ${misc:Depends}, pscheduler-server, pscheduler-test-trace
+Description: pScheduler bwctltracepath tool (DISABLED)
  bwctltracepath tool class for pScheduler
+ (DISABLED)

--- a/pscheduler-tool-bwctltraceroute/debian/changelog
+++ b/pscheduler-tool-bwctltraceroute/debian/changelog
@@ -1,8 +1,8 @@
 pscheduler-tool-bwctltraceroute (4.2.1~a1.0-1) perfsonar-4.2-snapshot; urgency=low
 
-  * New upstream version.
+  * Dummy package disabling all functionnality.
 
- -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Tue, 27 Aug 2019 17:33:18 +0000
+ -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Fri, 30 Aug 2019 16:37:51 +0000
 
 pscheduler-tool-bwctltraceroute (4.2.0-1) perfsonar-minor-staging; urgency=low
 

--- a/pscheduler-tool-bwctltraceroute/debian/control
+++ b/pscheduler-tool-bwctltraceroute/debian/control
@@ -12,9 +12,7 @@ Vcs-Browser: https://github.com/perfsonar/pscheduler
 
 Package: pscheduler-tool-bwctltraceroute
 Architecture: all
-Depends: ${misc:Depends}, python, python-pscheduler,
- pscheduler-server, pscheduler-test-trace,
- python-icmperror, traceroute,
- bwctl-client, bwctl-server
-Description: pScheduler bwctltraceroute tool
+Depends: ${misc:Depends}, pscheduler-server, pscheduler-test-trace
+Description: pScheduler bwctltraceroute tool (DISABLED)
  bwctltraceroute tool class for pScheduler
+ (DISABLED)


### PR DESCRIPTION
Was missed in previous changes.  Fixes #904