### PR TITLE
Fix for pscheduler-database-init conflict

### DIFF
--- a/postgresql-init/postgresql-init.spec
+++ b/postgresql-init/postgresql-init.spec
@@ -15,6 +15,7 @@ Group:		Unspecified
 Source:		%{name}-%{version}.tar.gz
 
 Provides:	%{name} = %{version}-%{release}
+#As of 4.3 we can probably get rid of below, but keep around until 4.4 to handle strange upgrade paths.
 Provides:	pscheduler-database-init
 
 

--- a/pscheduler-server/pscheduler-server.spec
+++ b/pscheduler-server/pscheduler-server.spec
@@ -45,7 +45,7 @@ Requires:	%{_pscheduler_postgresql_package}-plpython3 >= %{_pscheduler_postgresq
 Requires:	postgresql-load
 Requires:	pscheduler-account
 Requires:	pscheduler-core
-Requires:	pscheduler-database-init
+Requires:	postgresql-init
 Requires:	random-string >= 1.1
 
 # Daemons


### PR DESCRIPTION
This fixes the issue where perfsonar-testpoint won't install because it cannot decide which package that provides "pscheduler-database-init" to use. pscheduler-database-init isn't actually a package, it was just something I added as a _Provides_ back in 4.0 as a way for standalone packages to use "postgresql-init" and for installs with Esmond to use a separate set of packages for initialization. Since Mark  fixed it so esmond works with postgresql-init, this is a false distinction. As such changed the dependency in pscheduler-server to postgresql-init directly and things install as expected.

@mfeit-internet2 added you as reviewer to sanity check. @tonin not sure if there is similar work needed in Debian. This should be the only place we need this change due to the cleanup we have already done on toolkit and bundle packages. 