### PR TITLE
Adding a `pscheduler metrics` command for stats

### DIFF
--- a/pscheduler-core/pscheduler-core/Makefile
+++ b/pscheduler-core/pscheduler-core/Makefile
@@ -23,6 +23,7 @@ COMMANDS=\
 	cancel \
 	clock \
 	env \
+	metrics \
 	monitor \
 	ping \
 	plot-schedule \

--- a/pscheduler-core/pscheduler-core/debian/tests/control
+++ b/pscheduler-core/pscheduler-core/debian/tests/control
@@ -1,3 +1,3 @@
 Depends: @, pscheduler-bundle-full
-Tests: internal-nothing, internal-list, schedule, diags
+Tests: internal-nothing, internal-list, schedule, diags, metrics
 Restrictions: needs-root

--- a/pscheduler-core/pscheduler-core/debian/tests/metrics
+++ b/pscheduler-core/pscheduler-core/debian/tests/metrics
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+pscheduler metrics | grep '"is_paused": false'
+pscheduler metrics --prometheus | grep '^perfsonar_pscheduler_paused{state="is_paused"} 0'

--- a/pscheduler-core/pscheduler-core/metrics
+++ b/pscheduler-core/pscheduler-core/metrics
@@ -88,6 +88,8 @@ if options.timeout <= 0:
 if options.format not in ["json", "prometheus"]:
     pscheduler.fail("Format must be either json or prometheus")
 
+log = pscheduler.Log(verbose=False, debug=False, quiet=True, propagate=True)
+
 # Collect statistics
 all_stats = {}
 for k,v in pscheduler_stats.items():
@@ -97,7 +99,7 @@ for k,v in pscheduler_stats.items():
         status, result = pscheduler.url_get(url, throw=False, timeout=options.timeout)
 
         if status != 200:
-            log.error("Couldn't collect stats. API return code:{}, message: {}".format(status,
+            log.error("Couldn't collect stat for {}/{} API return code:{}, message: {}".format(k, state, status,
                     result[result.find('<title>') + 7 : result.find('</title>')]))
         else:
             if state != "":

--- a/pscheduler-core/pscheduler-core/metrics
+++ b/pscheduler-core/pscheduler-core/metrics
@@ -53,12 +53,15 @@ class VerbatimParser(optparse.OptionParser):
         return self.epilog
 
 opt_parser = VerbatimParser(
-    usage="Usage: %prog",
+    usage="Usage: %prog [options]",
     epilog=
 """
-Example:
+Examples:
 
   metrics
+      Output pScheduler statistics as a JSON object.
+
+  metrics --format prometheus
       Output pScheduler statistics in a format suitable for
       Prometheus node-exporter textfile collector
 """
@@ -66,7 +69,7 @@ Example:
 opt_parser.disable_interspersed_args()
 
 opt_parser.add_option("--format",
-                      help="Output format to use",
+                      help="The output format to use, either json (default) or prometheus",
                       default="json",
                       action="store", type="string",
                       dest="format")

--- a/pscheduler-core/pscheduler-core/metrics
+++ b/pscheduler-core/pscheduler-core/metrics
@@ -63,7 +63,11 @@ Examples:
 
   metrics --format prometheus
       Output pScheduler statistics in a format suitable for
-      Prometheus node-exporter textfile collector
+      Prometheus node-exporter textfile collector.
+
+  metrics --host pscheduler.host.net
+      Output pScheduler statistics coming from the
+      pscheduler.host.net machine.
 """
     )
 opt_parser.disable_interspersed_args()
@@ -73,6 +77,13 @@ opt_parser.add_option("--format",
                       default="json",
                       action="store", type="string",
                       dest="format")
+
+opt_parser.add_option("--host",
+                      help="Request statistics from named host",
+                      default=None,
+                      action="store", type="string",
+                      dest="host")
+
 opt_parser.add_option("--timeout", "-W",
                       help="How long to wait for the server to respond, in seconds (default 5)",
                       default=5,
@@ -95,7 +106,7 @@ all_stats = {}
 for k,v in pscheduler_stats.items():
     my_stat = {}
     for state in v["state"]:
-        url = pscheduler.api_url("localhost", v["url"] + state)
+        url = pscheduler.api_url(host=options.host, path=v["url"]+state)
         status, result = pscheduler.url_get(url, throw=False, timeout=options.timeout)
 
         if status != 200:
@@ -110,11 +121,11 @@ for k,v in pscheduler_stats.items():
     all_stats[k] = my_stat
 
 # Output the collected statistics
-output = ""
 if options.format == "json":
-    output = json.dumps(all_stats)
+    pscheduler.succeed_json(all_stats)
 
 elif options.format == "prometheus":
+    output = ""
     for k,v in all_stats.items():
         output += '# HELP {} {}\n'.format(pscheduler_stats[k]["prometheus-name"], pscheduler_stats[k]["desc"])
         output += '# TYPE {} {}\n'.format(pscheduler_stats[k]["prometheus-name"], pscheduler_stats[k]["type"])
@@ -124,9 +135,8 @@ elif options.format == "prometheus":
             else:
                 output += '{} {}\n'.format(pscheduler_stats[k]["prometheus-name"], int(value))
 
+    pscheduler.succeed(output)
+
 else:
-    output = "Unknown output format"
-
-
-print(output)
+    pscheduler.fail("Unknown output format")
 

--- a/pscheduler-core/pscheduler-core/metrics
+++ b/pscheduler-core/pscheduler-core/metrics
@@ -1,0 +1,127 @@
+#!/usr/bin/python3
+#
+# Output pScheduler statistics in the Prometheus format
+# To be used with node-exporter textfile collector
+#
+
+import optparse
+import pscheduler
+import json
+
+pscheduler.set_graceful_exit()
+
+# Known stats URL
+# Use an empty list for state when there are no subsequent stats
+
+pscheduler_stats = {
+    "paused": {
+        "url": "stat/control/pause",
+        "prometheus-name": "perfsonar_pscheduler_paused",
+        "desc": "pScheduler is paused",
+        "type": "gauge",
+        "state": [ "" ]
+        },
+    "archiving": {
+        "url": "stat/archiving/",
+        "prometheus-name": "perfsonar_pscheduler_archiving",
+        "desc": "pScheduler archiving queue",
+        "type": "gauge",
+        "state": [ "backlog", "upcoming" ]
+        },
+    "http-queue": {
+        "url": "stat/http-queue/",
+        "prometheus-name": "perfsonar_pscheduler_http_queue",
+        "desc": "pScheduler HTTP queue",
+        "type": "gauge",
+        "state": [ "backlog", "length" ]
+        },
+    "runs": {
+        "url": "stat/runs/",
+        "prometheus-name": "perfsonar_pscheduler_runs",
+        "desc": "Number of pScheduler runs in the different states",
+        "type": "gauge",
+        "state": [ "pending", "on-deck", "running", "cleanup", "finished", "overdue", "missed", "failed", "preempted", "nonstart" ]
+        }
+    }
+
+#
+# Gargle the arguments
+#
+
+class VerbatimParser(optparse.OptionParser):
+    def format_epilog(self, formatter):
+        return self.epilog
+
+opt_parser = VerbatimParser(
+    usage="Usage: %prog",
+    epilog=
+"""
+Example:
+
+  metrics
+      Output pScheduler statistics in a format suitable for
+      Prometheus node-exporter textfile collector
+"""
+    )
+opt_parser.disable_interspersed_args()
+
+opt_parser.add_option("--format",
+                      help="Output format to use",
+                      default="json",
+                      action="store", type="string",
+                      dest="format")
+opt_parser.add_option("--timeout", "-W",
+                      help="How long to wait for the server to respond, in seconds (default 5)",
+                      default=5,
+                      action="store", type="int",
+                      dest="timeout")
+
+
+(options, remaining_args) = opt_parser.parse_args()
+
+if options.timeout <= 0:
+    pscheduler.fail("Timeout must be >= 0")
+
+if options.format not in ["json", "prometheus"]:
+    pscheduler.fail("Format must be either json or prometheus")
+
+# Collect statistics
+all_stats = {}
+for k,v in pscheduler_stats.items():
+    my_stat = {}
+    for state in v["state"]:
+        url = pscheduler.api_url("localhost", v["url"] + state)
+        status, result = pscheduler.url_get(url, throw=False, timeout=options.timeout)
+
+        if status != 200:
+            log.error("Couldn't collect stats. API return code:{}, message: {}".format(status,
+                    result[result.find('<title>') + 7 : result.find('</title>')]))
+        else:
+            if state != "":
+                my_stat[state] = result
+            else:
+                my_stat = result
+
+    all_stats[k] = my_stat
+
+# Output the collected statistics
+output = ""
+if options.format == "json":
+    output = json.dumps(all_stats)
+
+elif options.format == "prometheus":
+    for k,v in all_stats.items():
+        output += '# HELP {} {}\n'.format(pscheduler_stats[k]["prometheus-name"], pscheduler_stats[k]["desc"])
+        output += '# TYPE {} {}\n'.format(pscheduler_stats[k]["prometheus-name"], pscheduler_stats[k]["type"])
+        for state, value in v.items():
+            if pscheduler_stats[k]["state"] != "":
+                output += '{}{{state="{}"}} {}\n'.format(pscheduler_stats[k]["prometheus-name"], state, int(value))
+            else:
+                output += '{} {}\n'.format(pscheduler_stats[k]["prometheus-name"], int(value))
+
+else:
+    output = "Unknown output format"
+
+
+print(output)
+


### PR DESCRIPTION
Outputs all the statistics available through the API.  It has 2 output format: json (default) and
prometheus to be used with prometheus-node-exporter textfile exporter.