### PR TITLE
RabbitMQ archiver fixes

### DIFF
--- a/pscheduler-archiver-rabbitmq/rabbitmq/archive
+++ b/pscheduler-archiver-rabbitmq/rabbitmq/archive
@@ -58,8 +58,8 @@ class AMQPExpiringConnection(object):
             return
 
         self.connection = amqp.connection.Connection(
-            host=self.hostname,
-            port=self.port,
+            host=self.host,
+            ssl=self.ssl,
             virtual_host=self.virtual_host,
 
             login_method=self.auth_method,
@@ -106,12 +106,24 @@ class AMQPExpiringConnection(object):
         self.expire_time = expire_time
 
         parsed_url = urllib.parse.urlparse(url)
-        if parsed_url.scheme not in ["amqp", "amqps"]:
+
+        # Set default port and SSL flag based on URL scheme
+        if (parsed_url.scheme == "amqp"):
+            port=5672
+            self.ssl=False
+        elif (parsed_url.scheme == "amqps"):
+            port=5671
+            self.ssl=True
+        else:
             raise ValueError("URL must be amqp[s]://...")
 
-        self.hostname=parsed_url.hostname
-        self.port=parsed_url.port
-        self.virtual_host=parsed_url.path or "/"
+        # Use port if specified in URL
+        if parsed_url.port:
+            port=parsed_url.port
+
+        self.host="%s:%s" % (parsed_url.hostname, port)
+        # Remove leading slash from path to match pika parsing convention
+        self.virtual_host=parsed_url.path[1:] or ""
 
         # These are the amqp module's defaults
         self.userid = parsed_url.username or "guest"
@@ -239,6 +251,7 @@ def archive(json):
         except KeyError:
             connection = AMQPExpiringConnection(data["_url"],
                                                 data.get("routing-key", ""),
+                                                exchange=data.get("exchange", ""),
                                                 expire_time=expires,
                                                 timeout=timeout
             )

--- a/pscheduler-archiver-rabbitmq/rabbitmq/archive
+++ b/pscheduler-archiver-rabbitmq/rabbitmq/archive
@@ -109,21 +109,21 @@ class AMQPExpiringConnection(object):
 
         # Set default port and SSL flag based on URL scheme
         if (parsed_url.scheme == "amqp"):
-            port=5672
-            self.ssl=False
+            port = 5672
+            self.ssl = False
         elif (parsed_url.scheme == "amqps"):
-            port=5671
-            self.ssl=True
+            port = 5671
+            self.ssl = True
         else:
             raise ValueError("URL must be amqp[s]://...")
 
         # Use port if specified in URL
         if parsed_url.port:
-            port=parsed_url.port
+            port = parsed_url.port
 
-        self.host="%s:%s" % (parsed_url.hostname, port)
+        self.host = "%s:%s" % (parsed_url.hostname, port)
         # Remove leading slash from path to match pika parsing convention
-        self.virtual_host=parsed_url.path[1:] or ""
+        self.virtual_host = parsed_url.path[1:] or ""
 
         # These are the amqp module's defaults
         self.userid = parsed_url.username or "guest"


### PR DESCRIPTION
- Enable SSL for amqps URL scheme
- Allow port to be configured
- Change vhost parsing to match pika conventions (omit leading slash)
- Include exchange