### PR TITLE
HTTP Archiver error handling fix

### DIFF
--- a/pscheduler-archiver-http/http/archive
+++ b/pscheduler-archiver-http/http/archive
@@ -185,7 +185,7 @@ def archive(json):
             retry_time = policy.retry(json["attempts"])
             if retry_time is not None:
                 result["retry"] = retry_time
-            return result
+        return result
 
     return {'succeeded': True}
 


### PR DESCRIPTION
Fixing indentation in http archiver that prevented archives without a retry policy from ever reporting a failure