### PR TITLE
Issue 1348 -Remove iperf3 server kill_processes call

### DIFF
--- a/pscheduler-tool-iperf3/iperf3/run
+++ b/pscheduler-tool-iperf3/iperf3/run
@@ -310,20 +310,6 @@ def run_server():
     diags = []
     #init command
     iperf3_args = [ iperf3_cmd, '-s', '-1', '--idle-timeout', str(test_duration), '--json']
-
-    # Once in awhile, a server process gets orphaned.  Find those and
-    # try to kill them.
-
-    try:
-        # Note that the client waits three seconds for us to start up,
-        # which is already overkill.  No need to add this to the run time.
-        pscheduler.kill_processes(iperf3_args, wait=1.0)
-    except Exception as ex:
-        return {"succeeded": False,
-                "diags": "",
-                "error": f'Found stray iperf3 server running could not terminate it: {str(ex)}'}
-
-
     iperf3_args.append("-p")
     iperf3_args.append(server_port)
 


### PR DESCRIPTION
This removes the call in iperf3 server to kill_processes per #1348. Adding this PR to save time if this is solution we want to go with, can dump otherwise.

Looking at history of code, this call (and its predecessors) pre-date the --idle-timeout option in iperf3. I think we can drop it entirely. Also, I wrote a test script to time teh code in question and was able to confirm some of Shawn's hosts see same behavior, so I suspect this is part (definitely not all) of some of the issues they have been seeing with test results.