### PR TITLE
5.1.0 JSON Validation Fix

### DIFF
--- a/python-pscheduler/pscheduler/pscheduler/jsonval.py
+++ b/python-pscheduler/pscheduler/pscheduler/jsonval.py
@@ -395,6 +395,13 @@ __dictionary__ = {
         "required": [ "style", "match" ]
     },
 
+    "StringNull": {
+        "anyOf": [
+            { "$ref": "#/pScheduler/String" },
+            { "type": "null" }
+        ]
+    },
+
     "EnumMatch": {
         "type": "object",
         "properties": {
@@ -606,8 +613,9 @@ __dictionary__ = {
     "ParticipantResult": {
         "type": "object",
         "properties": {
-            "diags": { "$ref": "#/pScheduler/String" },
-            "error": { "$ref": "#/pScheduler/String" },
+            "schema": { "$ref": "#/pScheduler/Cardinal" },
+            "diags": { "$ref": "#/pScheduler/StringNull" },
+            "error": { "$ref": "#/pScheduler/StringNull" },
             "succeeded": { "$ref": "#/pScheduler/Boolean" },
             "result":      { "$ref": "#/pScheduler/AnyJSON" },
             },


### PR DESCRIPTION
A bug was introduced in 5.1.0 that caused all tests of every type to fail with an "Invalid JSON" error. Error was thrown in at https://github.com/perfsonar/pscheduler/blob/8048b19c208acb49ac6e899f416ba4dd794a2a58/pscheduler-server/pscheduler-server/daemons/runner#L620C24-L620C24 

The problem was that the JSON returned by all tools would not validate since it contains a schema field and fields like "error" and "diags" can be None, which did not bass the string check. I updated jsonval.py to allow for these fields. 