### PR TITLE
Added packet-subcount option to utilize new powstream '-n' option

### DIFF
--- a/pscheduler-test-latencybg/latencybg/cli-to-spec
+++ b/pscheduler-test-latencybg/latencybg/cli-to-spec
@@ -74,6 +74,11 @@ opt_parser.add_option("-c", "--packet-count",
                       action="store", type="int",
                       dest="packet_count")
 
+opt_parser.add_option("--packet-subcount",
+                      help="The number of packets between each time results are fetched and reported",
+                      action="store", type="int",
+                      dest="packet_subcount")
+
 opt_parser.add_option("-t", "--duration",
                       help="The duration of he test in seconds or ISO8601",
                       action="store", type="string",
@@ -158,6 +163,9 @@ if options.duration is not None:
    
 if options.packet_count is not None:
    result['packet-count'] = options.packet_count
+
+if options.packet_subcount is not None:
+   result['packet-subcount'] = options.packet_subcount
 
 if options.packet_interval is not None:
    result['packet-interval'] = options.packet_interval

--- a/pscheduler-test-latencybg/latencybg/spec-format
+++ b/pscheduler-test-latencybg/latencybg/spec-format
@@ -20,6 +20,7 @@ if format == 'text/plain':
 Source   ............ {.section source}{@}{.or}Not Specified{.end}
 Destination ......... {.section dest}{@}{.or}Not Specified{.end}
 Packet Count ........ {.section packet-count}{@}{.or}Not Specified{.end}
+Packet Subcount ..... {.section packet-subcount}{@}{.or}Not Specified{.end}
 Packet Interval ..... {.section packet-interval}{@}{.or}Not Specified{.end}
 Packet Timeout. ..... {.section packet-timeout}{@}{.or}Not Specified{.end}
 Packet Padding. ..... {.section packet-padding}{@}{.or}Not Specified{.end}

--- a/pscheduler-test-latencybg/latencybg/validate.py
+++ b/pscheduler-test-latencybg/latencybg/validate.py
@@ -50,6 +50,10 @@ REQUEST_SCHEMA = {
                 "description": "The number of packets to send before reporting a result",
                 "$ref": "#/pScheduler/Cardinal"
             },
+            "packet-subcount": {
+                "description": "The number of packets before fetching and reporting an intermediate result",
+                "$ref": "#/pScheduler/Cardinal"
+            },
             "packet-interval": {
                 "description": "The number of seconds to delay between sending packets",
                 "$ref": "#/local/packet-interval"

--- a/pscheduler-tool-powstream/powstream/run
+++ b/pscheduler-tool-powstream/powstream/run
@@ -161,10 +161,16 @@ for rarg in POWSTREAM_RANGE_ARGS:
         
 #set interval,count and timeout to ensure consistent with duration
 count = test_spec.get('packet-count', DEFAULT_PACKET_COUNT)
+subcount = test_spec.get('packet-subcount', 0)
 interval = test_spec.get('packet-interval', DEFAULT_PACKET_INTERVAL)
 packet_timeout = test_spec.get('packet-timeout', 0)
 powstream_args.append('-c')
 powstream_args.append(str(count))
+if subcount > 0:
+    # Add full subsession reports
+    powstream_args.append('-N')
+    powstream_args.append(str(subcount))
+    powstream_args.append('-n')
 powstream_args.append('-i')
 powstream_args.append(str(interval))
 if packet_timeout > 0:


### PR DESCRIPTION
Support for powstreams (upcoming) "-n" option ha been added. A new "packet-subcount" parameter has been added for the powstream tool plugin. When "packet-subcount" is set to <num>  "-N <num> -n " is added to te powstream commandline, enabling output and parsing of raw measurement data for each sub-session of <num> packets.

Note that (as warned in the man-page of powstream) the -n option may cause skipped packets in an owamp-session not to to be interpreted totally correct, i.e. be reported as lost packets.