### PR TITLE
Update s3-benchmark tool to allow objects smaller than 1000 bytes

### DIFF
--- a/pscheduler-tool-s3-benchmark/s3-benchmark/can-run
+++ b/pscheduler-tool-s3-benchmark/s3-benchmark/can-run
@@ -34,7 +34,7 @@ except ValueError as ex:
     })
 
 try:
-    if json['spec']['object-size'] < 1000 or json['spec']['object-size'] >= 1099511627776:
+    if json['spec']['object-size'] < 0 or json['spec']['object-size'] >= 1099511627776:
         pscheduler.succeed_json({
             "can-run": False,
             "reasons": [ "Object size outside supported size range for this tool" ]


### PR DESCRIPTION
Update s3-benchmark tool to allow objects of any non-negative size to be used.