### PR TITLE
Update python-pscheduler to start rsyslog if not running

### DIFF
--- a/python-pscheduler/pscheduler/unibuild-packaging/rpm/python-pscheduler.spec
+++ b/python-pscheduler/pscheduler/unibuild-packaging/rpm/python-pscheduler.spec
@@ -160,12 +160,12 @@ EOF
 fi
 
 systemctl enable rsyslog
-systemctl reload-or-try-restart rsyslog
+systemctl reload-or-restart rsyslog
 POST-WRAPPER-EOF
 
 
 %postun
-systemctl reload-or-try-restart rsyslog
+systemctl reload-or-restart rsyslog
 
 
 %files -f INSTALLED_FILES


### PR DESCRIPTION
Fixes #1520 