### PR TITLE
API /runs returns 404 if a task doesn't exist

### DIFF
--- a/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/runs.py
+++ b/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/runs.py
@@ -117,7 +117,7 @@ def tasks_uuid_runs(task):
     cursor.close()
 
     if not exists:
-        return not_found(f'No task "{task}" is available.')
+        return not_found(f'Task "{task}" does not exist.')
 
     if request.method == 'GET':
 

--- a/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/runs.py
+++ b/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/runs.py
@@ -109,17 +109,16 @@ def tasks_uuid_runs(task):
     if not uuid_is_valid(task):
         return not_found()
 
-    cursor = dbcursor_query("""SELECT EXISTS (SELECT * FROM run JOIN task ON task.id = run.task
-                              WHERE task.uuid = %s)""",
-                            [ task ])
-
-    exists = cursor.fetchone()[0]
-    cursor.close()
-
-    if not exists:
-        return not_found(f'Task "{task}" does not exist.')
-
     if request.method == 'GET':
+        cursor = dbcursor_query("""SELECT EXISTS (SELECT * FROM run JOIN task ON task.id = run.task
+                                  WHERE task.uuid = %s)""",
+                                [task])
+
+        exists = cursor.fetchone()[0]
+        cursor.close()
+
+        if not exists:
+            return not_found(f'Task "{task}" does not exist.')
 
         query = "SELECT '" + base_url() + """/' || run.uuid
              FROM

--- a/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/runs.py
+++ b/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/runs.py
@@ -109,6 +109,16 @@ def tasks_uuid_runs(task):
     if not uuid_is_valid(task):
         return not_found()
 
+    cursor = dbcursor_query("""SELECT EXISTS (SELECT * FROM run JOIN task ON task.id = run.task
+                              WHERE task.uuid = %s)""",
+                            [ task ])
+
+    exists = cursor.fetchone()[0]
+    cursor.close()
+
+    if not exists:
+        return not_found(f'No task "{task}" is available.')
+
     if request.method == 'GET':
 
         query = "SELECT '" + base_url() + """/' || run.uuid


### PR DESCRIPTION
Fixes #1461 