### PR TITLE
Fix in clockstate to initialize result.

### DIFF
--- a/python-pscheduler/pscheduler/pscheduler/clockstate.py
+++ b/python-pscheduler/pscheduler/pscheduler/clockstate.py
@@ -147,6 +147,7 @@ def _chronyc_status():
         if "Last offset" in parameter:
             offset_str = parameter
 
+    result = {}
     try:
         offset = offset_str[offset_str.find(':'):]
         if offset != "":


### PR DESCRIPTION
In 5.2.0 branch some of the recent changes made led to 'pscheduler troubleshoot` throwing the following:

```
[root@ps-dev-staging-el9-tk1 andy]# pscheduler troubleshoot
Performing basic troubleshooting of ps-dev-staging-el9-tk1.

ps-dev-staging-el9-tk1:

  Checking that host "ps-dev-staging-el9-tk1" resolves... 10.128.0.26
  Measuring MTU... 65535 (Local)
  Looking for pScheduler... OK.
  Fetching API level... 6
  Checking clock... Failed.

Unable to fetch clock state: name 'result' is not defined
```

This is just a fix to init the value and confirmed it fixes the issue. 