### PR TITLE
fixes Issue 1516

### DIFF
--- a/pscheduler-core/pscheduler-core/plot-schedule
+++ b/pscheduler-core/pscheduler-core/plot-schedule
@@ -10,12 +10,11 @@ import datetime
 import optparse
 import os
 import pscheduler
-import pytz
 import shutil
 import sys
 import tempfile
 import urllib.parse
-
+from dateutil import tz
 
 pscheduler.set_graceful_exit()
 
@@ -35,7 +34,7 @@ def get_time_with_delta(string):
         absolute = pscheduler.iso8601_as_datetime(string)
         # Default behavior is to localize naive times.
         if absolute.tzinfo is None:
-            absolute = pytz.utc.localize(absolute)
+            absolute = absolute.astimezone(tz.UTC)
             return pscheduler.datetime_as_iso8601(absolute)
     except ValueError:
         pass

--- a/pscheduler-core/pscheduler-core/schedule
+++ b/pscheduler-core/pscheduler-core/schedule
@@ -10,11 +10,10 @@ import datetime
 import optparse
 import os
 import pscheduler
-import pytz
 import shlex
 import sys
 import urllib
-
+from dateutil import tz
 
 pscheduler.set_graceful_exit()
 
@@ -34,7 +33,7 @@ def get_time_with_delta(string):
         absolute = pscheduler.iso8601_as_datetime(string)
         # Default behavior is to localize naive times.
         if absolute.tzinfo is None:
-            absolute = pytz.utc.localize(absolute)
+            absolute = absolute.astimezone(tz.UTC)
             return pscheduler.datetime_as_iso8601(absolute)
     except ValueError:
         pass

--- a/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/admin.py
+++ b/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/admin.py
@@ -4,10 +4,8 @@
 
 import datetime
 import pscheduler
-import pytz
 import socket
 import time
-import tzlocal
 import werkzeug
 
 from pschedulerapiserver import application

--- a/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/admin.py
+++ b/pscheduler-server/pscheduler-server/api-server/pschedulerapiserver/admin.py
@@ -2,17 +2,14 @@
 # Administrative Information
 #
 
-import datetime
 import pscheduler
 import socket
-import time
 import werkzeug
 
 from pschedulerapiserver import application
 
 from .access import *
 from .address import *
-from .args import arg_integer
 from .dbcursor import dbcursor_query
 from .limitproc import *
 from .log import log

--- a/pscheduler-server/pscheduler-server/unibuild-packaging/rpm/pscheduler-server.spec
+++ b/pscheduler-server/pscheduler-server/unibuild-packaging/rpm/pscheduler-server.spec
@@ -73,7 +73,6 @@ Requires:	mod_ssl
 Requires:	mod_wsgi > 4.0
 Requires:	%{_pscheduler_python}-parse-crontab
 Requires:	%{_pscheduler_python}-pscheduler >= 5.1.0
-Requires:	%{_pscheduler_python}-pytz
 
 # General
 BuildRequires:	pscheduler-rpm

--- a/pscheduler-tool-powstream/powstream/powstream_utils.py
+++ b/pscheduler-tool-powstream/powstream/powstream_utils.py
@@ -12,8 +12,8 @@ import re
 import shutil
 import sys
 import time
-import pytz
 from subprocess import call
+from dateutil import tz
 
 #output contants
 DELAY_BUCKET_DIGITS = 2 #number of digits to round delay buckets
@@ -113,7 +113,7 @@ def handle_run_error(emitter, msg, diags=None, do_log=True, exception=False):
 # Calculates time to sleep or returns True if end time reached
 def sleep_or_end(seconds, end_time, parent_pid):
     #determine if we need to exit
-    now = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+    now = datetime.datetime.now(tz=tz.UTC)
     if now >= end_time:
         #check if we are at or beyond endtime
         return True

--- a/pscheduler-tool-powstream/powstream/run
+++ b/pscheduler-tool-powstream/powstream/run
@@ -5,16 +5,12 @@
 
 import atexit
 import datetime
-import fcntl
-import json
 import pscheduler
 import sys
 import os
 import signal
-import time
 from powstream_defaults import *
-from powstream_utils import get_config, parse_raw_owamp_output, cleanup_dir, cleanup_file, handle_run_error, sleep_or_end, graceful_exit
-from subprocess import Popen, PIPE, call
+from powstream_utils import get_config, parse_raw_owamp_output, cleanup_dir, cleanup_file, handle_run_error, graceful_exit
 from dateutil import tz
 
 #track when this run starts - make sure it is aware that it is UTC

--- a/pscheduler-tool-powstream/powstream/run
+++ b/pscheduler-tool-powstream/powstream/run
@@ -12,13 +12,13 @@ import sys
 import os
 import signal
 import time
-import pytz
 from powstream_defaults import *
 from powstream_utils import get_config, parse_raw_owamp_output, cleanup_dir, cleanup_file, handle_run_error, sleep_or_end, graceful_exit
 from subprocess import Popen, PIPE, call
+from dateutil import tz
 
 #track when this run starts - make sure it is aware that it is UTC
-start_time = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+start_time = datetime.datetime.now(tz=tz.UTC)
 #create tag to include in data directory based on current time
 #prevents old processes from stomping on new during restart
 time_tag = start_time.strftime("%Y%b%dT%H%M%S%f")

--- a/python-pscheduler/pscheduler/pscheduler/clockstate.py
+++ b/python-pscheduler/pscheduler/pscheduler/clockstate.py
@@ -7,8 +7,7 @@ import pscheduler
 import datetime
 import ntplib
 import psutil
-import pytz
-import tzlocal
+from dateutil import tz
 
 # The ntp_adjtime code is the only bit of BWCTL (actually BWCTL2) that
 # survived into pScheduler.
@@ -228,9 +227,8 @@ def clock_state():
 
     # Grab the time now in case anyting below takes awhile.
 
-    utc = datetime.datetime.utcnow()
-    local_tz = tzlocal.get_localzone()
-    time_here = pytz.utc.localize(utc).astimezone(local_tz)
+    utc = datetime.datetime.now(tz=tz.UTC)
+    time_here = utc.astimezone(tz.tzlocal())
 
     raw_offset = time_here.strftime("%z")
     if len(raw_offset):

--- a/python-pscheduler/pscheduler/pscheduler/iso8601.py
+++ b/python-pscheduler/pscheduler/pscheduler/iso8601.py
@@ -5,7 +5,6 @@ Functions for dealing with ISO 8601 timestamps and intervals
 import datetime
 import isodate
 
-from tzlocal import get_localzone
 from dateutil.tz import tzlocal
 
 
@@ -30,7 +29,7 @@ def iso8601_as_datetime(iso,
     try:
         parsed = isodate.parse_datetime(iso)
         if localize and parsed.tzinfo is None:
-            parsed = get_localzone().localize(parsed)
+            parsed = parsed.astimezone(tzlocal())
         return parsed
     except isodate.isoerror.ISO8601Error as ex:
         raise ValueError("Invalid ISO8601 date")

--- a/python-pscheduler/pscheduler/pscheduler/pstime.py
+++ b/python-pscheduler/pscheduler/pscheduler/pstime.py
@@ -3,10 +3,8 @@
 #
 
 import datetime
-import pytz
 
-from dateutil.tz import tzlocal
-
+from dateutil.tz import tzlocal, UTC
 
 #
 # Timedelta
@@ -51,7 +49,7 @@ def time_epoch():
     """
     Return the date and time of the Unix epoch
     """
-    return datetime.datetime.fromtimestamp(0, pytz.utc)
+    return datetime.datetime.fromtimestamp(0, UTC)
 
 
 def time_now():

--- a/python-pscheduler/pscheduler/unibuild-packaging/rpm/python-pscheduler.spec
+++ b/python-pscheduler/pscheduler/unibuild-packaging/rpm/python-pscheduler.spec
@@ -43,8 +43,6 @@ Requires:	%{_pscheduler_python}-py-radix
 Requires:	pscheduler-jq-library
 Requires:	%{_pscheduler_python}-pycurl
 Requires:	%{_pscheduler_python}-pyjq >= 2.2.0
-Requires:	%{_pscheduler_python}-tzlocal
-Requires:	%{_pscheduler_python}-pytz
 Requires:	rsyslog
 Requires:	logrotate
 Requires:       numactl
@@ -72,8 +70,6 @@ BuildRequires:	%{_pscheduler_python}-py-radix
 BuildRequires:	pscheduler-jq-library
 BuildRequires:	%{_pscheduler_python}-pycurl
 BuildRequires:	%{_pscheduler_python}-pyjq >= 2.2.0
-BuildRequires:	%{_pscheduler_python}-tzlocal
-BuildRequires:	%{_pscheduler_python}-pytz
 BuildRequires:  numactl
 
 %define limit_config %{_pscheduler_sysconfdir}/limits.conf


### PR DESCRIPTION
Migrated away from ```pytz``` (+ ```tzlocal```) to a PEP 495-compliant implementation: ```dateutil```

Also removed unused imports from the modified python files.


The only place where ```pytz``` is still referenced - [setup.py](https://github.com/perfsonar/pscheduler/blob/master/python-pscheduler/pscheduler/setup.py)
Reason: ```unibuild build``` fails because of the [setup.patch](https://github.com/perfsonar/pscheduler/blob/master/python-pscheduler/pscheduler/unibuild-packaging/deb/patches/setup.patch) 

Don\`t see why this patch is required, but... maybe there is a reason behind it